### PR TITLE
修复0.3.0开旧会话加载首token-平均-失败

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _ev-scaffold2
 /.idea/modules.xml
 /.idea/pi-desktop.iml
 /.idea/vcs.xml
+/.pi-glla/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-desktop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pi Desktop — Electron + Vue3 Agent Workspace",
   "main": "./out/main/index.js",
   "author": "ImYoyoData",

--- a/src/agent-worker/context-usage.ts
+++ b/src/agent-worker/context-usage.ts
@@ -1,5 +1,11 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
-import type { ContextUsageSegment, SessionContextUsage } from "../shared/protocol";
+import type {
+  ContextUsageSegment,
+  SessionContextUsage,
+} from "../shared/protocol";
+import type { SessionTiming } from "../shared/session-timing";
+
+export type { SessionTiming } from "../shared/session-timing";
 
 function charsToTokens(chars: number): number {
   return Math.max(0, Math.ceil(Math.max(0, chars) / 4));
@@ -16,7 +22,8 @@ function contentChars(content: unknown): number {
     if (typeof p.thinking === "string") n += p.thinking.length;
     if (typeof p.summary === "string") n += p.summary.length;
     if (p.type === "toolCall") {
-      n += String(p.name ?? "").length + JSON.stringify(p.arguments ?? {}).length;
+      n +=
+        String(p.name ?? "").length + JSON.stringify(p.arguments ?? {}).length;
     }
     // Cap image payloads so screenshots don't explode the estimate.
     if (typeof p.data === "string") n += Math.min(p.data.length, 512);
@@ -24,7 +31,10 @@ function contentChars(content: unknown): number {
   return n;
 }
 
-function estimateMessageTokens(message: unknown): { role: string; tokens: number } {
+function estimateMessageTokens(message: unknown): {
+  role: string;
+  tokens: number;
+} {
   if (!message || typeof message !== "object") return { role: "", tokens: 0 };
   const msg = message as Record<string, unknown>;
   const role = typeof msg.role === "string" ? msg.role : "";
@@ -36,7 +46,10 @@ function estimateMessageTokens(message: unknown): { role: string; tokens: number
   }
   if (role === "branchSummary" || role === "compactionSummary") {
     const summary = typeof msg.summary === "string" ? msg.summary : "";
-    return { role, tokens: charsToTokens(summary.length || contentChars(msg.content)) };
+    return {
+      role,
+      tokens: charsToTokens(summary.length || contentChars(msg.content)),
+    };
   }
   if (role === "bashExecution") {
     const command = typeof msg.command === "string" ? msg.command : "";
@@ -87,7 +100,8 @@ function buildSegments(active: AgentSession): ContextUsageSegment[] {
     for (const message of active.messages ?? []) {
       const { role, tokens } = estimateMessageTokens(message);
       if (!tokens) continue;
-      if (role === "branchSummary" || role === "compactionSummary") summarized += tokens;
+      if (role === "branchSummary" || role === "compactionSummary")
+        summarized += tokens;
       else if (role === "toolResult") toolResults += tokens;
       else conversation += tokens;
     }
@@ -99,8 +113,10 @@ function buildSegments(active: AgentSession): ContextUsageSegment[] {
   if (system > 0) segments.push({ id: "system", tokens: system });
   if (tools > 0) segments.push({ id: "tools", tokens: tools });
   if (summarized > 0) segments.push({ id: "summarized", tokens: summarized });
-  if (toolResults > 0) segments.push({ id: "toolResults", tokens: toolResults });
-  if (conversation > 0) segments.push({ id: "conversation", tokens: conversation });
+  if (toolResults > 0)
+    segments.push({ id: "toolResults", tokens: toolResults });
+  if (conversation > 0)
+    segments.push({ id: "conversation", tokens: conversation });
   return segments;
 }
 
@@ -130,7 +146,9 @@ function scaleMessageSegments(
   return [...fixed, ...scaled].filter((s) => s.tokens > 0);
 }
 
-export function readContextUsage(active: AgentSession): SessionContextUsage | null {
+export function readContextUsage(
+  active: AgentSession,
+): SessionContextUsage | null {
   let toolCalls: number | null = null;
   let messageCount: number | null = null;
   let turns: number | null = null;
@@ -143,14 +161,24 @@ export function readContextUsage(active: AgentSession): SessionContextUsage | nu
     const stats = active.getSessionStats();
     if (stats && typeof stats === "object") {
       if (typeof stats.toolCalls === "number") toolCalls = stats.toolCalls;
-      const users = typeof stats.userMessages === "number" ? stats.userMessages : 0;
-      const assistants = typeof stats.assistantMessages === "number" ? stats.assistantMessages : 0;
-      const toolResults = typeof stats.toolResults === "number" ? stats.toolResults : 0;
+      const users =
+        typeof stats.userMessages === "number" ? stats.userMessages : 0;
+      const assistants =
+        typeof stats.assistantMessages === "number"
+          ? stats.assistantMessages
+          : 0;
+      const toolResults =
+        typeof stats.toolResults === "number" ? stats.toolResults : 0;
       messageCount = users + assistants + toolResults;
       turns = users;
       steps = assistants;
       const tokens = stats.tokens as
-        | { input?: unknown; output?: unknown; cacheRead?: unknown; cacheWrite?: unknown }
+        | {
+            input?: unknown;
+            output?: unknown;
+            cacheRead?: unknown;
+            cacheWrite?: unknown;
+          }
         | undefined;
       if (tokens && typeof tokens === "object") {
         const num = (v: unknown): number | null =>
@@ -215,14 +243,6 @@ export function readContextUsage(active: AgentSession): SessionContextUsage | nu
  * (first token → message_end × reported output tokens). Totals accumulate
  * across the whole session; `snapshot()` also includes the in-flight step.
  */
-export type SessionTiming = {
-  llmMs: number;
-  ttftMs: number;
-  ttftSteps: number;
-  decodeMs: number;
-  outputTokens: number;
-};
-
 const ZERO_TIMING: SessionTiming = {
   llmMs: 0,
   ttftMs: 0,
@@ -243,7 +263,9 @@ function outputOfMessage(raw: unknown): number {
   const usage = msg.usage;
   if (!usage || typeof usage !== "object") return 0;
   const u = usage as Record<string, unknown>;
-  return typeof u.output === "number" && Number.isFinite(u.output) && u.output > 0
+  return typeof u.output === "number" &&
+    Number.isFinite(u.output) &&
+    u.output > 0
     ? u.output
     : 0;
 }
@@ -268,7 +290,9 @@ export class SessionTimingTracker {
     }
     if (type === "message_update") {
       if (this.firstToken === null && this.stepStart !== null) {
-        const ev = raw.assistantMessageEvent as Record<string, unknown> | undefined;
+        const ev = raw.assistantMessageEvent as
+          | Record<string, unknown>
+          | undefined;
         const evType = typeof ev?.type === "string" ? ev.type : "";
         if (
           evType === "text_delta" ||
@@ -306,7 +330,11 @@ export class SessionTimingTracker {
       }
       return;
     }
-    if (type === "agent_end" || type === "agent_settled" || type === "turn_end") {
+    if (
+      type === "agent_end" ||
+      type === "agent_settled" ||
+      type === "turn_end"
+    ) {
       if (this.stepStart !== null) {
         this.timing.llmMs += Math.max(0, now - this.stepStart);
         this.stepStart = null;
@@ -319,11 +347,19 @@ export class SessionTimingTracker {
   /** Current totals, including the in-flight step when one is open. */
   snapshot(): SessionTiming {
     const now = Date.now();
-    const inflight = this.stepStart !== null ? Math.max(0, now - this.stepStart) : 0;
+    const inflight =
+      this.stepStart !== null ? Math.max(0, now - this.stepStart) : 0;
     return {
       ...this.timing,
       llmMs: this.timing.llmMs + inflight,
     };
+  }
+
+  restore(timing: SessionTiming): void {
+    this.timing = { ...timing };
+    this.turnStart = null;
+    this.stepStart = null;
+    this.firstToken = null;
   }
 
   reset(): void {

--- a/src/agent-worker/runtime.ts
+++ b/src/agent-worker/runtime.ts
@@ -1,4 +1,5 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { readFileSync, writeFileSync } from "node:fs";
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import {
 	createAgentSessionFromServices,
@@ -50,7 +51,15 @@ import { createAskUserToolDefinition } from "./ask-user-tool";
 import { commandShouldStartBackground } from "../shared/bash-background";
 import { createTrackedBashOperations } from "./bash-run-tracker";
 import { createBrowserToolDefinitions } from "./browser-tools";
-import { readContextUsage, SessionTimingTracker } from "./context-usage";
+import {
+	readContextUsage,
+	SessionTimingTracker,
+	type SessionTiming,
+} from "./context-usage";
+import {
+	parseSessionTiming,
+	sessionTimingPath,
+} from "../shared/session-timing";
 import { pruneOldToolResults } from "./tool-result-prune";
 import { createDesktopExtensionUIContext } from "./extension-ui-context";
 import { handleRpcResponse, rpcToMain, setRpcWorkspaceRoot } from "./main-rpc";
@@ -68,6 +77,46 @@ let session: AgentSession | null = null;
 let initStarted = false;
 let runTracker: ReturnType<typeof createTrackedBashOperations> | null = null;
 const timingTracker = new SessionTimingTracker();
+let lastPersistedTimingJson = "";
+
+function restoreTimingFromDisk(filePath: string): void {
+	timingTracker.reset();
+	lastPersistedTimingJson = "";
+	try {
+		const raw = readFileSync(sessionTimingPath(filePath), "utf8");
+		const timing = parseSessionTiming(JSON.parse(raw));
+		if (timing) {
+			timingTracker.restore(timing);
+			lastPersistedTimingJson = JSON.stringify(timing);
+		}
+	} catch {
+		// ignore
+	}
+}
+
+function persistTimingToDisk(timing: SessionTiming): void {
+	const filePath = session?.sessionFile;
+	if (!filePath) return;
+	try {
+		const json = JSON.stringify(timing);
+		if (json === lastPersistedTimingJson) return;
+		writeFileSync(sessionTimingPath(filePath), json, "utf8");
+		lastPersistedTimingJson = json;
+	} catch {
+		// ignore
+	}
+}
+
+function timingStats() {
+	const timing = timingTracker.snapshot();
+	return {
+		llmDurationMs: timing.llmMs > 0 ? timing.llmMs : null,
+		ttftMs: timing.ttftSteps > 0 ? timing.ttftMs / timing.ttftSteps : null,
+		ttftSteps: timing.ttftSteps > 0 ? timing.ttftSteps : null,
+		tokensPerSecond:
+			timing.decodeMs > 0 ? timing.outputTokens / (timing.decodeMs / 1000) : null,
+	};
+}
 let desktopSecurity: DesktopSecuritySettings = { ...DEFAULT_DESKTOP_SECURITY };
 const sessionAllows = new Set<SecurityCategory>();
 /** Once unlocked this session, keep browser_* available for follow-up clicks/fills. */
@@ -94,10 +143,7 @@ function syncBuiltinBrowserTools(active: AgentSession, enable: boolean): void {
 		.map((t) => t.name)
 		.filter(isBuiltinBrowserToolName);
 	const next = [...new Set([...withoutBrowser, ...browserNames])];
-	if (
-		next.length !== current.length ||
-		next.some((n) => !current.includes(n))
-	) {
+	if (next.length !== current.length || next.some((n) => !current.includes(n))) {
 		active.setActiveToolsByName(next);
 	}
 }
@@ -158,7 +204,9 @@ async function rollbackUserTurn(
 }
 
 /** Abandon the earliest user turn that still carries image parts (heals poisoned history). */
-async function rollbackFirstImageUserTurn(active: AgentSession): Promise<boolean> {
+async function rollbackFirstImageUserTurn(
+	active: AgentSession,
+): Promise<boolean> {
 	const users = active.getUserMessagesForForking();
 	for (const user of users) {
 		const entry = active.sessionManager.getEntry(user.entryId);
@@ -197,7 +245,11 @@ function lastAssistantErrorMessage(active: AgentSession): string | null {
 			errorMessage?: string;
 		};
 		if (m?.role !== "assistant") continue;
-		if (m.stopReason === "error" && typeof m.errorMessage === "string" && m.errorMessage) {
+		if (
+			m.stopReason === "error" &&
+			typeof m.errorMessage === "string" &&
+			m.errorMessage
+		) {
 			return m.errorMessage;
 		}
 		return null;
@@ -212,8 +264,7 @@ function sanitizeAgentEvent(
 	const type = event.type;
 	if (type === "agent_end") {
 		const messages = Array.isArray(event.messages) ? event.messages : [];
-		const last =
-			messages.length > 0 ? messages[messages.length - 1] : undefined;
+		const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
 		let lastError: string | undefined;
 		if (last && typeof last === "object") {
 			const msg = last as { stopReason?: unknown; errorMessage?: unknown };
@@ -289,14 +340,16 @@ async function initSession(
 		: SessionManager.create(cwd);
 	// New sessions must hit disk before idle-destroy / cold reopen (avoids id mismatch).
 	ensureSessionFileOnDisk(sessionManager);
+	const initialSessionFile = sessionManager.getSessionFile();
+	if (initialSessionFile) {
+		restoreTimingFromDisk(initialSessionFile);
+	}
 	const settingsManager = SettingsManager.create(cwd, agentDir, {
 		projectTrusted: Boolean(projectTrusted),
 	});
 	const builtinBrowserSkillDir = resolveBuiltinBrowserSkillDir(
 		workerDirname(),
-		typeof process.resourcesPath === "string"
-			? process.resourcesPath
-			: undefined,
+		typeof process.resourcesPath === "string" ? process.resourcesPath : undefined,
 	);
 	const services = await createAgentSessionServices({
 		cwd,
@@ -435,7 +488,13 @@ async function initSession(
 		cwd: sessionManager.getCwd(),
 		resources,
 	});
-	// contextUsage is pulled via get_state after attach; emitting here races ready handshake.
+	setTimeout(() => {
+		try {
+			if (session) emitContextUsage(session);
+		} catch {
+			// ignore
+		}
+	}, 0);
 }
 
 function requireSession(): AgentSession {
@@ -469,6 +528,7 @@ function emitContextUsage(active: AgentSession): void {
 	const usage = readContextUsage(active);
 	if (!usage) return;
 	const timing = timingTracker.snapshot();
+	persistTimingToDisk(timing);
 	post({
 		kind: "event",
 		event: {
@@ -518,6 +578,7 @@ export async function handleWorkerMessage(msg: WorkerInbound): Promise<void> {
 	}
 	if (msg.kind === "shutdown") {
 		runTracker?.endAllRuns();
+		persistTimingToDisk(timingTracker.snapshot());
 		process.exit(0);
 		return;
 	}
@@ -689,7 +750,10 @@ async function runCommand(id: string, command: AgentCommand): Promise<void> {
 					sessionId: active.sessionId,
 					sessionName: active.sessionName,
 					messageCount: active.messages.length,
-					contextUsage: readContextUsage(active),
+					contextUsage: (() => {
+						const usage = readContextUsage(active);
+						return usage ? { ...usage, ...timingStats() } : null;
+					})(),
 				},
 			});
 			return;

--- a/src/main/agent-worker-host.ts
+++ b/src/main/agent-worker-host.ts
@@ -1,9 +1,13 @@
 import { app, BrowserWindow, utilityProcess } from "electron";
 import path from "node:path";
-import type { WorkerInbound, WorkerOutbound } from "../shared/agent-worker-messages";
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+} from "../shared/agent-worker-messages";
 import type { SpawnWorker, WorkerHandle } from "./session-broker";
 import { getDesktopSecuritySettings } from "./desktop-security-host";
 import { buildAgentWorkerEnv } from "./pi-path-env";
+import { withProxyEnv } from "./proxy-host";
 import {
   PI_DESKTOP_NODE_PATH_ENV,
   PI_DESKTOP_PI_CLI_PATH_ENV,
@@ -21,7 +25,9 @@ function workerScriptPath(): string {
 /** Latest resource summary per session (tools / extensions / skills). */
 const sessionResources = new Map<string, WorkerResourceSummary>();
 
-export function getSessionResources(sessionId: string): WorkerResourceSummary | null {
+export function getSessionResources(
+  sessionId: string,
+): WorkerResourceSummary | null {
   return sessionResources.get(sessionId) ?? null;
 }
 
@@ -31,7 +37,8 @@ export function clearSessionResources(sessionId: string): void {
 
 function broadcastWorkerResourcesReady(sessionId: string): void {
   for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) win.webContents.send(IpcChannels.sessions.workerReady, sessionId);
+    if (!win.isDestroyed())
+      win.webContents.send(IpcChannels.sessions.workerReady, sessionId);
   }
 }
 
@@ -67,7 +74,9 @@ function waitForReady(
             `[pi-desktop] worker ready: ${r.extensionCount} extension(s), ${r.skillCount} skill(s), ${r.agentsFileCount ?? 0} agents file(s), ${r.activeTools.length} tool(s)`,
           );
           if (r.agentsFilePaths?.length) {
-            console.info(`[pi-desktop] agents files: ${r.agentsFilePaths.join(" | ")}`);
+            console.info(
+              `[pi-desktop] agents files: ${r.agentsFilePaths.join(" | ")}`,
+            );
           }
           for (const line of r.diagnostics) {
             console.warn(`[pi-desktop] worker resource: ${line}`);
@@ -90,18 +99,20 @@ function waitForReady(
 
 export function createUtilityProcessSpawnWorker(): SpawnWorker {
   return async (cwd, filePath) => {
-    const workerEnv = buildAgentWorkerEnv(
-      { ...process.env },
-      {
-        searchRoots: [
-          app.getAppPath(),
-          path.join(app.getAppPath(), ".."),
-          process.cwd(),
-          // electron-vite: out/main → repo root (dev) / resources (packaged)
-          path.resolve(__dirname, "../.."),
-          path.resolve(__dirname, "../../.."),
-        ],
-      },
+    const workerEnv = withProxyEnv(
+      buildAgentWorkerEnv(
+        { ...process.env },
+        {
+          searchRoots: [
+            app.getAppPath(),
+            path.join(app.getAppPath(), ".."),
+            process.cwd(),
+            // electron-vite: out/main → repo root (dev) / resources (packaged)
+            path.resolve(__dirname, "../.."),
+            path.resolve(__dirname, "../../.."),
+          ],
+        },
+      ),
     );
     const cliForLog = workerEnv[PI_DESKTOP_PI_CLI_PATH_ENV];
     const nodeForLog = workerEnv[PI_DESKTOP_NODE_PATH_ENV];
@@ -129,7 +140,10 @@ export function createUtilityProcessSpawnWorker(): SpawnWorker {
     // prompt() never resolves, and the session looks disconnected with no response.
     // Relay to the main-process console so dev terminals still see worker logs.
     const workerTag = `[worker:${child.pid ?? "?"}]`;
-    const relay = (stream: NodeJS.ReadableStream | null, isErr: boolean): void => {
+    const relay = (
+      stream: NodeJS.ReadableStream | null,
+      isErr: boolean,
+    ): void => {
       stream?.on("data", (chunk: Buffer) => {
         const text = String(chunk).replace(/\r?\n$/, "");
         if (isErr) console.error(workerTag, text);

--- a/src/main/git-host.ts
+++ b/src/main/git-host.ts
@@ -9,8 +9,13 @@ import type {
   GitOpResult,
   GitRemote,
 } from "../shared/git-types";
-import { classifyGitFailure, detailFromGitOutput, isEmbeddedGitMissing } from "./git-errors";
+import {
+  classifyGitFailure,
+  detailFromGitOutput,
+  isEmbeddedGitMissing,
+} from "./git-errors";
 import { isGitIgnoredPath } from "./git-ignore-store";
+import { withProxyEnv } from "./proxy-host";
 
 /** Quick local ops (status / diff / branch). */
 const GIT_TIMEOUT_MS = 30_000;
@@ -69,7 +74,14 @@ export type GitBranchesResult = {
   remote: string[];
 };
 
-export type { GitOpResult, GitRemote, GitLogEntry, GitLogResult, GitErrorCode, GitConflictContentResult };
+export type {
+  GitOpResult,
+  GitRemote,
+  GitLogEntry,
+  GitLogResult,
+  GitErrorCode,
+  GitConflictContentResult,
+};
 
 type PorcelainEntry = {
   path: string;
@@ -78,7 +90,13 @@ type PorcelainEntry = {
   worktreeStatus: string;
 };
 
-type GitFail = { ok: false; message: string; code: GitErrorCode; stdout: string; stderr: string };
+type GitFail = {
+  ok: false;
+  message: string;
+  code: GitErrorCode;
+  stdout: string;
+  stderr: string;
+};
 
 function fail(code: GitErrorCode, detail = ""): GitOpResult {
   return { ok: false, code, message: detail.trim() || code };
@@ -122,14 +140,15 @@ async function gitSpawn(
   try {
     const result = await exec(args, cwd, {
       maxBuffer,
-      env: { ...process.env, LC_ALL: "C" },
+      env: withProxyEnv({ ...process.env, LC_ALL: "C" }),
       signal: AbortSignal.timeout(timeoutMs),
     });
     const stdout = toText(result.stdout);
     const stderr = toText(result.stderr);
     if (result.exitCode !== 0) {
       const message =
-        detailFromGitOutput(stderr, stdout) || `git ${args[0] ?? "command"} failed`;
+        detailFromGitOutput(stderr, stdout) ||
+        `git ${args[0] ?? "command"} failed`;
       const err = new Error(message) as Error & {
         stderr: string;
         stdout: string;
@@ -146,7 +165,9 @@ async function gitSpawn(
       const stderr = toText(err.stderr);
       const stdout = toText(err.stdout);
       const message =
-        detailFromGitOutput(stderr, stdout) || err.message || "git executable failed";
+        detailFromGitOutput(stderr, stdout) ||
+        err.message ||
+        "git executable failed";
       const wrapped = new Error(message) as Error & {
         stderr: string;
         stdout: string;
@@ -171,7 +192,9 @@ async function gitAllowFail(
     const e = err as { stderr?: string; stdout?: string; message?: string };
     const stderr = (e.stderr || "").trim();
     const stdout = (e.stdout || "").trim();
-    const detail = detailFromGitOutput(stderr, stdout) || (e.message || "git command failed").trim();
+    const detail =
+      detailFromGitOutput(stderr, stdout) ||
+      (e.message || "git command failed").trim();
     return {
       ok: false,
       message: detail,
@@ -210,12 +233,16 @@ function parsePorcelainV1(output: string): PorcelainEntry[] {
 
 const CONFLICT = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
 
-export function classify(entry: PorcelainEntry): Pick<GitFileStatus, "status" | "code"> {
+export function classify(
+  entry: PorcelainEntry,
+): Pick<GitFileStatus, "status" | "code"> {
   const pair = `${entry.indexStatus}${entry.worktreeStatus}`;
   if (pair === "??") return { status: "untracked", code: "U" };
-  if (CONFLICT.has(pair) || pair.includes("U")) return { status: "conflict", code: "C" };
+  if (CONFLICT.has(pair) || pair.includes("U"))
+    return { status: "conflict", code: "C" };
   if (pair.includes("D")) return { status: "deleted", code: "D" };
-  if (pair.includes("R") || pair.includes("C")) return { status: "renamed", code: "R" };
+  if (pair.includes("R") || pair.includes("C"))
+    return { status: "renamed", code: "R" };
   if (pair.includes("A")) return { status: "added", code: "A" };
   return { status: "modified", code: "M" };
 }
@@ -260,7 +287,9 @@ function hasLocalGitDir(cwd: string): boolean {
   }
 }
 
-async function readStatusEntries(repositoryRoot: string): Promise<PorcelainEntry[]> {
+async function readStatusEntries(
+  repositoryRoot: string,
+): Promise<PorcelainEntry[]> {
   const output = await git(repositoryRoot, [
     "status",
     "--porcelain=v1",
@@ -270,7 +299,9 @@ async function readStatusEntries(repositoryRoot: string): Promise<PorcelainEntry
   return parsePorcelainV1(output);
 }
 
-export async function getWorkspaceGitStatus(cwd: string): Promise<GitStatusResult> {
+export async function getWorkspaceGitStatus(
+  cwd: string,
+): Promise<GitStatusResult> {
   let repositoryRoot: string | null;
   try {
     repositoryRoot = await findRepositoryRoot(cwd);
@@ -287,14 +318,19 @@ export async function getWorkspaceGitStatus(cwd: string): Promise<GitStatusResul
     }
     throw err;
   }
-  if (!repositoryRoot) return { isGitRepository: false, branch: null, files: [] };
+  if (!repositoryRoot)
+    return { isGitRepository: false, branch: null, files: [] };
 
   let branch: string | null = null;
   try {
-    const name = (await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    const name = (
+      await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])
+    ).trim();
     branch = name || null;
     if (branch === "HEAD") {
-      const short = (await git(repositoryRoot, ["rev-parse", "--short", "HEAD"])).trim();
+      const short = (
+        await git(repositoryRoot, ["rev-parse", "--short", "HEAD"])
+      ).trim();
       branch = short ? `detached@${short}` : "HEAD";
     }
   } catch {
@@ -344,7 +380,9 @@ function createAddedFilePatch(gitPath: string, content: string): string {
   if (hasTrailingNewline) lines.pop();
   const body = lines.map((line) => `+${line}`).join("\n");
   const noNewlineMarker =
-    !hasTrailingNewline && lines.length > 0 ? "\n\\ No newline at end of file" : "";
+    !hasTrailingNewline && lines.length > 0
+      ? "\n\\ No newline at end of file"
+      : "";
   return [
     `diff --git a/${gitPath} b/${gitPath}`,
     "new file mode 100644",
@@ -367,7 +405,15 @@ async function createTrackedFilePatch(
   try {
     return await git(
       repositoryRoot,
-      ["diff", "--no-color", "--no-ext-diff", "--unified=3", "HEAD", "--", ...paths],
+      [
+        "diff",
+        "--no-color",
+        "--no-ext-diff",
+        "--unified=3",
+        "HEAD",
+        "--",
+        ...paths,
+      ],
       TEXT_PREVIEW_MAX_BYTES * 4,
     );
   } catch {
@@ -399,11 +445,16 @@ export async function getGitFileDiff(
   if (!repositoryRoot) return { supported: false };
 
   const resolvedFilePath = path.resolve(cwd, relativePath);
-  if (!isWithin(cwd, resolvedFilePath) || !isWithin(repositoryRoot, resolvedFilePath)) {
+  if (
+    !isWithin(cwd, resolvedFilePath) ||
+    !isWithin(repositoryRoot, resolvedFilePath)
+  ) {
     return { supported: false };
   }
 
-  const repoRelative = toGitPath(path.relative(repositoryRoot, resolvedFilePath));
+  const repoRelative = toGitPath(
+    path.relative(repositoryRoot, resolvedFilePath),
+  );
   let entries: PorcelainEntry[];
   try {
     entries = await readStatusEntries(repositoryRoot);
@@ -426,8 +477,10 @@ export async function getGitFileDiff(
         "--",
         headPath,
       ]);
-      if (!patch.includes("\n@@ ") && !patch.startsWith("@@ ")) return { supported: false };
-      const oldContent = (await readHeadContent(repositoryRoot, headPath)) ?? "";
+      if (!patch.includes("\n@@ ") && !patch.startsWith("@@ "))
+        return { supported: false };
+      const oldContent =
+        (await readHeadContent(repositoryRoot, headPath)) ?? "";
       return { supported: true, status, patch, oldContent, newContent: "" };
     } catch {
       return { supported: false };
@@ -440,7 +493,8 @@ export async function getGitFileDiff(
   } catch {
     return { supported: false };
   }
-  if (!stat.isFile() || stat.size > TEXT_PREVIEW_MAX_BYTES) return { supported: false };
+  if (!stat.isFile() || stat.size > TEXT_PREVIEW_MAX_BYTES)
+    return { supported: false };
 
   const currentBuffer = fs.readFileSync(resolvedFilePath);
   if (hasNullByte(currentBuffer)) return { supported: false };
@@ -463,7 +517,10 @@ export async function getGitFileDiff(
         repoRelative,
         entry.originalPath,
       );
-      if (trackedPatch === null || (!trackedPatch.includes("\n@@ ") && !trackedPatch.startsWith("@@ "))) {
+      if (
+        trackedPatch === null ||
+        (!trackedPatch.includes("\n@@ ") && !trackedPatch.startsWith("@@ "))
+      ) {
         if (status === "added") {
           patch = createAddedFilePatch(repoRelative, newContent);
           oldContent = "";
@@ -476,7 +533,8 @@ export async function getGitFileDiff(
     }
   }
 
-  if (!patch.includes("\n@@ ") && !patch.startsWith("@@ ")) return { supported: false };
+  if (!patch.includes("\n@@ ") && !patch.startsWith("@@ "))
+    return { supported: false };
   return { supported: true, status, patch, oldContent, newContent };
 }
 
@@ -486,14 +544,20 @@ export async function listBranches(cwd: string): Promise<GitBranchesResult> {
 
   let current: string | null = null;
   try {
-    current = (await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim() || null;
+    current =
+      (
+        await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])
+      ).trim() || null;
   } catch {
     current = null;
   }
 
   let local: string[] = [];
   try {
-    const out = await git(repositoryRoot, ["branch", "--format=%(refname:short)"]);
+    const out = await git(repositoryRoot, [
+      "branch",
+      "--format=%(refname:short)",
+    ]);
     local = out
       .split(/\r?\n/)
       .map((l) => l.trim())
@@ -504,7 +568,11 @@ export async function listBranches(cwd: string): Promise<GitBranchesResult> {
 
   let remote: string[] = [];
   try {
-    const out = await git(repositoryRoot, ["branch", "-r", "--format=%(refname:short)"]);
+    const out = await git(repositoryRoot, [
+      "branch",
+      "-r",
+      "--format=%(refname:short)",
+    ]);
     remote = out
       .split(/\r?\n/)
       .map((l) => l.trim())
@@ -577,12 +645,18 @@ export async function restorePaths(
         "--",
         ...tracked,
       ]);
-      if (!checkout.ok) return fail(checkout.code, checkout.message || restore.message);
+      if (!checkout.ok)
+        return fail(checkout.code, checkout.message || restore.message);
     }
   }
 
   if (untracked.length) {
-    const clean = await gitAllowFail(repositoryRoot, ["clean", "-f", "--", ...untracked]);
+    const clean = await gitAllowFail(repositoryRoot, [
+      "clean",
+      "-f",
+      "--",
+      ...untracked,
+    ]);
     if (!clean.ok) return fail(clean.code, clean.message);
   }
 
@@ -603,14 +677,21 @@ export async function fetchRepo(
     remotes = [];
   }
   if (!remotes.length) {
-    return fail("no_remote", "No remotes configured. Add origin (or another remote) first.");
+    return fail(
+      "no_remote",
+      "No remotes configured. Add origin (or another remote) first.",
+    );
   }
 
   const name = (remote || "").trim();
   const args = name
     ? ["fetch", name, "--prune"]
     : ["fetch", "--all", "--prune"];
-  const result = await gitAllowFail(repositoryRoot, args, GIT_NETWORK_TIMEOUT_MS);
+  const result = await gitAllowFail(
+    repositoryRoot,
+    args,
+    GIT_NETWORK_TIMEOUT_MS,
+  );
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true, message: result.stdout.trim() || undefined };
 }
@@ -623,7 +704,10 @@ function withCheckoutHint(code: GitErrorCode, message: string): string {
   return message ? `${message}\n${hint}` : hint;
 }
 
-export async function checkoutBranch(cwd: string, branch: string): Promise<GitOpResult> {
+export async function checkoutBranch(
+  cwd: string,
+  branch: string,
+): Promise<GitOpResult> {
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const name = branch.trim();
@@ -648,11 +732,20 @@ export async function checkoutBranch(cwd: string, branch: string): Promise<GitOp
 
       if (isRemoteTracking) {
         if (branches.local.includes(short)) {
-          const localCheckout = await gitAllowFail(repositoryRoot, ["switch", short]);
+          const localCheckout = await gitAllowFail(repositoryRoot, [
+            "switch",
+            short,
+          ]);
           if (localCheckout.ok) return { ok: true };
-          const legacy = await gitAllowFail(repositoryRoot, ["checkout", short]);
+          const legacy = await gitAllowFail(repositoryRoot, [
+            "checkout",
+            short,
+          ]);
           if (legacy.ok) return { ok: true };
-          return fail(localCheckout.code, withCheckoutHint(localCheckout.code, localCheckout.message));
+          return fail(
+            localCheckout.code,
+            withCheckoutHint(localCheckout.code, localCheckout.message),
+          );
         }
         const tracked = await gitAllowFail(repositoryRoot, [
           "switch",
@@ -671,7 +764,10 @@ export async function checkoutBranch(cwd: string, branch: string): Promise<GitOp
           name,
         ]);
         if (create.ok) return { ok: true };
-        return fail(tracked.code, withCheckoutHint(tracked.code, tracked.message));
+        return fail(
+          tracked.code,
+          withCheckoutHint(tracked.code, tracked.message),
+        );
       }
     }
   }
@@ -700,7 +796,10 @@ export async function createBranch(
   return { ok: true };
 }
 
-export async function mergeBranch(cwd: string, branch: string): Promise<GitOpResult> {
+export async function mergeBranch(
+  cwd: string,
+  branch: string,
+): Promise<GitOpResult> {
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const name = branch.trim();
@@ -710,13 +809,20 @@ export async function mergeBranch(cwd: string, branch: string): Promise<GitOpRes
   return { ok: true, message: result.stdout.trim() || undefined };
 }
 
-export async function deleteBranch(cwd: string, branch: string): Promise<GitOpResult> {
+export async function deleteBranch(
+  cwd: string,
+  branch: string,
+): Promise<GitOpResult> {
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const name = branch.trim();
   if (!name) return fail("invalid_args", "Branch name required");
 
-  const current = await gitAllowFail(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const current = await gitAllowFail(repositoryRoot, [
+    "rev-parse",
+    "--abbrev-ref",
+    "HEAD",
+  ]);
   if (current.ok && current.stdout.trim() === name) {
     return fail(
       "invalid_args",
@@ -739,7 +845,11 @@ export async function renameBranch(
   const from = branch.trim();
   const to = nextName.trim();
   if (!from || !to) return fail("invalid_args", "Branch name required");
-  if (from === to) return fail("invalid_args", "New branch name is the same as the current name");
+  if (from === to)
+    return fail(
+      "invalid_args",
+      "New branch name is the same as the current name",
+    );
   const result = await gitAllowFail(repositoryRoot, ["branch", "-m", from, to]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
@@ -822,8 +932,14 @@ export async function addRemote(
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const remoteName = name.trim();
   const remoteUrl = url.trim();
-  if (!remoteName || !remoteUrl) return fail("invalid_args", "Remote name and URL required");
-  const result = await gitAllowFail(repositoryRoot, ["remote", "add", remoteName, remoteUrl]);
+  if (!remoteName || !remoteUrl)
+    return fail("invalid_args", "Remote name and URL required");
+  const result = await gitAllowFail(repositoryRoot, [
+    "remote",
+    "add",
+    remoteName,
+    remoteUrl,
+  ]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
 }
@@ -837,7 +953,8 @@ export async function setRemoteUrl(
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const remoteName = name.trim();
   const remoteUrl = url.trim();
-  if (!remoteName || !remoteUrl) return fail("invalid_args", "Remote name and URL required");
+  if (!remoteName || !remoteUrl)
+    return fail("invalid_args", "Remote name and URL required");
   const result = await gitAllowFail(repositoryRoot, [
     "remote",
     "set-url",
@@ -848,12 +965,19 @@ export async function setRemoteUrl(
   return { ok: true };
 }
 
-export async function removeRemote(cwd: string, name: string): Promise<GitOpResult> {
+export async function removeRemote(
+  cwd: string,
+  name: string,
+): Promise<GitOpResult> {
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const remoteName = name.trim();
   if (!remoteName) return fail("invalid_args", "Remote name required");
-  const result = await gitAllowFail(repositoryRoot, ["remote", "remove", remoteName]);
+  const result = await gitAllowFail(repositoryRoot, [
+    "remote",
+    "remove",
+    remoteName,
+  ]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
 }
@@ -882,7 +1006,10 @@ export async function listLog(
 ): Promise<GitLogResult> {
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return { entries: [] };
-  const n = Math.max(1, Math.min(200, Math.floor(limit) || GIT_LOG_DEFAULT_LIMIT));
+  const n = Math.max(
+    1,
+    Math.min(200, Math.floor(limit) || GIT_LOG_DEFAULT_LIMIT),
+  );
   try {
     const out = await git(repositoryRoot, [
       "log",
@@ -977,7 +1104,12 @@ export async function restoreFileToCommit(
   if (!/^[0-9a-fA-F]{4,40}$/.test(rev)) {
     return fail("invalid_args", "Invalid commit hash");
   }
-  const result = await gitAllowFail(repositoryRoot, ["checkout", rev, "--", gitPath]);
+  const result = await gitAllowFail(repositoryRoot, [
+    "checkout",
+    rev,
+    "--",
+    gitPath,
+  ]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
 }
@@ -1041,7 +1173,11 @@ export async function resetToCommit(
   return { ok: true, message: `reset ${mode}` };
 }
 
-function assertPathsWithin(cwd: string, paths: string[], repositoryRoot: string): string[] | null {
+function assertPathsWithin(
+  cwd: string,
+  paths: string[],
+  repositoryRoot: string,
+): string[] | null {
   const gitPaths: string[] = [];
   for (const p of paths ?? []) {
     if (typeof p !== "string" || !p.trim()) continue;
@@ -1060,7 +1196,8 @@ export async function stagePaths(
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const gitPaths = assertPathsWithin(cwd, paths, repositoryRoot);
-  if (gitPaths === null || gitPaths.length === 0) return fail("invalid_args", "No valid paths to stage");
+  if (gitPaths === null || gitPaths.length === 0)
+    return fail("invalid_args", "No valid paths to stage");
   const result = await gitAllowFail(repositoryRoot, ["add", "--", ...gitPaths]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
@@ -1074,8 +1211,14 @@ export async function unstagePaths(
   const repositoryRoot = await findRepositoryRoot(cwd);
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
   const gitPaths = assertPathsWithin(cwd, paths, repositoryRoot);
-  if (gitPaths === null || gitPaths.length === 0) return fail("invalid_args", "No valid paths to unstage");
-  const result = await gitAllowFail(repositoryRoot, ["restore", "--staged", "--", ...gitPaths]);
+  if (gitPaths === null || gitPaths.length === 0)
+    return fail("invalid_args", "No valid paths to unstage");
+  const result = await gitAllowFail(repositoryRoot, [
+    "restore",
+    "--staged",
+    "--",
+    ...gitPaths,
+  ]);
   if (!result.ok) return fail(result.code, result.message);
   return { ok: true };
 }
@@ -1091,16 +1234,31 @@ export async function pullRepo(cwd: string): Promise<GitOpResult> {
     remotes = [];
   }
   if (!remotes.length) {
-    return fail("no_remote", "No remotes configured. Add origin (or another remote) first.");
+    return fail(
+      "no_remote",
+      "No remotes configured. Add origin (or another remote) first.",
+    );
   }
 
-  const rebase = await gitAllowFail(repositoryRoot, ["pull", "--rebase"], GIT_NETWORK_TIMEOUT_MS);
-  if (rebase.ok) return { ok: true, message: rebase.stdout.trim() || undefined };
+  const rebase = await gitAllowFail(
+    repositoryRoot,
+    ["pull", "--rebase"],
+    GIT_NETWORK_TIMEOUT_MS,
+  );
+  if (rebase.ok)
+    return { ok: true, message: rebase.stdout.trim() || undefined };
   if (rebase.code === "conflicts") return fail("conflicts", rebase.message);
 
-  const plain = await gitAllowFail(repositoryRoot, ["pull"], GIT_NETWORK_TIMEOUT_MS);
+  const plain = await gitAllowFail(
+    repositoryRoot,
+    ["pull"],
+    GIT_NETWORK_TIMEOUT_MS,
+  );
   if (plain.ok) return { ok: true, message: plain.stdout.trim() || undefined };
-  return fail(plain.code !== "unknown" ? plain.code : rebase.code, plain.message || rebase.message);
+  return fail(
+    plain.code !== "unknown" ? plain.code : rebase.code,
+    plain.message || rebase.message,
+  );
 }
 
 export async function pushRepo(cwd: string): Promise<GitOpResult> {
@@ -1114,10 +1272,17 @@ export async function pushRepo(cwd: string): Promise<GitOpResult> {
     remotes = [];
   }
   if (!remotes.length) {
-    return fail("no_remote", "No remotes configured. Add origin (or another remote) first.");
+    return fail(
+      "no_remote",
+      "No remotes configured. Add origin (or another remote) first.",
+    );
   }
 
-  const push = await gitAllowFail(repositoryRoot, ["push"], GIT_NETWORK_TIMEOUT_MS);
+  const push = await gitAllowFail(
+    repositoryRoot,
+    ["push"],
+    GIT_NETWORK_TIMEOUT_MS,
+  );
   if (push.ok) return { ok: true, message: push.stdout.trim() || undefined };
   if (push.code !== "no_upstream" && push.code !== "unknown") {
     return fail(push.code, push.message);
@@ -1125,7 +1290,9 @@ export async function pushRepo(cwd: string): Promise<GitOpResult> {
 
   let branch = "";
   try {
-    branch = (await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    branch = (
+      await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])
+    ).trim();
   } catch {
     return fail(push.code, push.message);
   }
@@ -1137,7 +1304,8 @@ export async function pushRepo(cwd: string): Promise<GitOpResult> {
     ["push", "-u", origin.name, branch],
     GIT_NETWORK_TIMEOUT_MS,
   );
-  if (upstream.ok) return { ok: true, message: upstream.stdout.trim() || undefined };
+  if (upstream.ok)
+    return { ok: true, message: upstream.stdout.trim() || undefined };
   return fail(upstream.code, upstream.message || push.message);
 }
 
@@ -1146,7 +1314,10 @@ async function readIndexStage(
   stage: 2 | 3,
   repoRelative: string,
 ): Promise<string> {
-  const result = await gitAllowFail(repositoryRoot, ["show", `:${stage}:${repoRelative}`]);
+  const result = await gitAllowFail(repositoryRoot, [
+    "show",
+    `:${stage}:${repoRelative}`,
+  ]);
   if (!result.ok) return "";
   return result.stdout;
 }
@@ -1156,7 +1327,9 @@ async function conflictSideLabels(
 ): Promise<{ ours: string; theirs: string }> {
   let ours = "HEAD";
   try {
-    const branch = (await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    const branch = (
+      await git(repositoryRoot, ["rev-parse", "--abbrev-ref", "HEAD"])
+    ).trim();
     if (branch && branch !== "HEAD") ours = branch;
   } catch {
     /* keep HEAD */
@@ -1164,9 +1337,18 @@ async function conflictSideLabels(
 
   let theirs = "theirs";
   for (const headRef of ["MERGE_HEAD", "REBASE_HEAD"] as const) {
-    const verify = await gitAllowFail(repositoryRoot, ["rev-parse", "-q", "--verify", headRef]);
+    const verify = await gitAllowFail(repositoryRoot, [
+      "rev-parse",
+      "-q",
+      "--verify",
+      headRef,
+    ]);
     if (!verify.ok) continue;
-    const nameRev = await gitAllowFail(repositoryRoot, ["name-rev", "--name-only", headRef]);
+    const nameRev = await gitAllowFail(repositoryRoot, [
+      "name-rev",
+      "--name-only",
+      headRef,
+    ]);
     if (nameRev.ok && nameRev.stdout.trim()) {
       theirs = nameRev.stdout.trim().replace(/^remotes\//, "");
       break;
@@ -1184,11 +1366,16 @@ export async function getConflictContent(
   if (!repositoryRoot) return { supported: false, reason: "not_repo" };
 
   const resolvedFilePath = path.resolve(cwd, relativePath);
-  if (!isWithin(cwd, resolvedFilePath) || !isWithin(repositoryRoot, resolvedFilePath)) {
+  if (
+    !isWithin(cwd, resolvedFilePath) ||
+    !isWithin(repositoryRoot, resolvedFilePath)
+  ) {
     return { supported: false, reason: "not_found" };
   }
 
-  const repoRelative = toGitPath(path.relative(repositoryRoot, resolvedFilePath));
+  const repoRelative = toGitPath(
+    path.relative(repositoryRoot, resolvedFilePath),
+  );
 
   let stat: fs.Stats;
   try {
@@ -1197,7 +1384,8 @@ export async function getConflictContent(
     return { supported: false, reason: "not_found" };
   }
   if (!stat.isFile()) return { supported: false, reason: "not_found" };
-  if (stat.size > TEXT_PREVIEW_MAX_BYTES) return { supported: false, reason: "too_large" };
+  if (stat.size > TEXT_PREVIEW_MAX_BYTES)
+    return { supported: false, reason: "too_large" };
 
   const currentBuffer = fs.readFileSync(resolvedFilePath);
   if (hasNullByte(currentBuffer)) return { supported: false, reason: "binary" };
@@ -1223,11 +1411,16 @@ export async function resolveConflictPath(
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
 
   const resolvedFilePath = path.resolve(cwd, relativePath);
-  if (!isWithin(cwd, resolvedFilePath) || !isWithin(repositoryRoot, resolvedFilePath)) {
+  if (
+    !isWithin(cwd, resolvedFilePath) ||
+    !isWithin(repositoryRoot, resolvedFilePath)
+  ) {
     return fail("invalid_args", `Path outside workspace: ${relativePath}`);
   }
 
-  const repoRelative = toGitPath(path.relative(repositoryRoot, resolvedFilePath));
+  const repoRelative = toGitPath(
+    path.relative(repositoryRoot, resolvedFilePath),
+  );
   fs.writeFileSync(resolvedFilePath, content, "utf8");
 
   const add = await gitAllowFail(repositoryRoot, ["add", "--", repoRelative]);
@@ -1244,14 +1437,24 @@ export async function checkoutConflictSide(
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
 
   const resolvedFilePath = path.resolve(cwd, relativePath);
-  if (!isWithin(cwd, resolvedFilePath) || !isWithin(repositoryRoot, resolvedFilePath)) {
+  if (
+    !isWithin(cwd, resolvedFilePath) ||
+    !isWithin(repositoryRoot, resolvedFilePath)
+  ) {
     return fail("invalid_args", `Path outside workspace: ${relativePath}`);
   }
 
-  const repoRelative = toGitPath(path.relative(repositoryRoot, resolvedFilePath));
+  const repoRelative = toGitPath(
+    path.relative(repositoryRoot, resolvedFilePath),
+  );
   const sideFlag = side === "ours" ? "--ours" : "--theirs";
 
-  const checkout = await gitAllowFail(repositoryRoot, ["checkout", sideFlag, "--", repoRelative]);
+  const checkout = await gitAllowFail(repositoryRoot, [
+    "checkout",
+    sideFlag,
+    "--",
+    repoRelative,
+  ]);
   if (!checkout.ok) return fail(checkout.code, checkout.message);
 
   const add = await gitAllowFail(repositoryRoot, ["add", "--", repoRelative]);
@@ -1264,7 +1467,9 @@ export async function abortMerge(cwd: string): Promise<GitOpResult> {
   if (!repositoryRoot) return fail("not_repo", "Not a git repository");
 
   const gitDir = (await git(repositoryRoot, ["rev-parse", "--git-dir"])).trim();
-  const absGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(repositoryRoot, gitDir);
+  const absGitDir = path.isAbsolute(gitDir)
+    ? gitDir
+    : path.join(repositoryRoot, gitDir);
   const rebasing =
     fs.existsSync(path.join(absGitDir, "rebase-merge")) ||
     fs.existsSync(path.join(absGitDir, "rebase-apply"));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,8 +57,12 @@ import {
 	registerExtensionUiIpc,
 } from "./extension-ui-host";
 import { registerSecurityTrustIpc } from "./security-trust-ipc";
-import { ensureLanConsoleFromSettings, registerLanConsoleIpc } from "./lan-console";
+import {
+	ensureLanConsoleFromSettings,
+	registerLanConsoleIpc,
+} from "./lan-console";
 import { ensurePiAgentEnvironment } from "./pi-env";
+import { initProxy, registerProxyIpc } from "./proxy-host";
 import { installApplicationMenu } from "./app-menu";
 import { enableHardwareAcceleration } from "./gpu-flags";
 import {
@@ -96,9 +100,7 @@ guardChromiumCacheDirs();
  */
 const allowMultiInstance = process.env.PI_DESKTOP_ALLOW_MULTI_INSTANCE === "1";
 const gotSingleInstanceLock =
-	app.isPackaged && !allowMultiInstance
-		? app.requestSingleInstanceLock()
-		: true;
+	app.isPackaged && !allowMultiInstance ? app.requestSingleInstanceLock() : true;
 if (!gotSingleInstanceLock) {
 	app.quit();
 } else {
@@ -175,8 +177,7 @@ function boot(): void {
 						const category = params.category;
 						const toolName =
 							typeof params.toolName === "string" ? params.toolName : "";
-						const summary =
-							typeof params.summary === "string" ? params.summary : "";
+						const summary = typeof params.summary === "string" ? params.summary : "";
 						if (category !== "bash" && category !== "write") {
 							throw new Error("desktop.permissionAsk: invalid category");
 						}
@@ -201,11 +202,7 @@ function boot(): void {
 							questions,
 						});
 					} else if (msg.method === "desktop.extensionUi") {
-						result = await handleExtensionUiRpc(
-							sessionId,
-							msg.id,
-							msg.params ?? {},
-						);
+						result = await handleExtensionUiRpc(sessionId, msg.id, msg.params ?? {});
 					} else {
 						result = await browserAutomation.handle({
 							method: msg.method as BrowserRpcMethod,
@@ -375,9 +372,8 @@ function boot(): void {
 						return;
 					}
 					if (permission === "media") {
-						const mediaTypes = (
-							details as { mediaTypes?: Array<"audio" | "video"> }
-						).mediaTypes;
+						const mediaTypes = (details as { mediaTypes?: Array<"audio" | "video"> })
+							.mediaTypes;
 						const ok = await ensureDarwinMediaAccess(mediaTypes);
 						callback(ok);
 						return;
@@ -405,6 +401,8 @@ function boot(): void {
 
 		// Show UI as soon as possible — defer agent env setup and non-critical
 		// hosts (ASR / update / market / CLI) so the window paints first.
+		void initProxy();
+		registerProxyIpc();
 		createMainWindow();
 
 		setImmediate(() => {

--- a/src/main/proxy-host.ts
+++ b/src/main/proxy-host.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { app, BrowserWindow, ipcMain, session } from "electron";
+import { IpcChannels } from "../shared/protocol";
+import {
+	DEFAULT_PROXY_SETTINGS,
+	normalizeProxyUrl,
+	PROXY_ENV_KEYS,
+	proxyEnvFromPacResult,
+	proxyEnvFromUrl,
+	PROXY_MODES,
+	type ProxySettings,
+} from "../shared/proxy";
+
+const SYSTEM_PROXY_PROBE_URL = "https://api.openai.com";
+
+let currentSettings: ProxySettings = { ...DEFAULT_PROXY_SETTINGS };
+let systemProxyEnv: Record<string, string> = {};
+
+function settingsPath(): string {
+	return join(app.getPath("userData"), "proxy.json");
+}
+
+function readSettingsFromDisk(): ProxySettings {
+	try {
+		const raw = JSON.parse(
+			readFileSync(settingsPath(), "utf8"),
+		) as Partial<ProxySettings>;
+		const mode = PROXY_MODES.includes(raw.mode as ProxySettings["mode"])
+			? (raw.mode as ProxySettings["mode"])
+			: DEFAULT_PROXY_SETTINGS.mode;
+		return {
+			mode,
+			url: typeof raw.url === "string" ? raw.url : "",
+		};
+	} catch {
+		return { ...DEFAULT_PROXY_SETTINGS };
+	}
+}
+
+function writeSettingsToDisk(settings: ProxySettings): void {
+	const file = settingsPath();
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, `${JSON.stringify(settings, null, 2)}\n`, {
+		encoding: "utf8",
+		mode: 0o600,
+	});
+}
+
+async function applyProxySettings(settings: ProxySettings): Promise<void> {
+	const ses = session.defaultSession;
+	if (settings.mode === "custom") {
+		const url = normalizeProxyUrl(settings.url);
+		if (url) {
+			await ses.setProxy({ proxyRules: url });
+			return;
+		}
+		await ses.setProxy({ mode: "direct" });
+		return;
+	}
+	if (settings.mode === "system") {
+		await ses.setProxy({ mode: "system" });
+		return;
+	}
+	await ses.setProxy({ mode: "direct" });
+}
+
+async function refreshSystemProxyEnv(): Promise<void> {
+	if (currentSettings.mode !== "system") {
+		systemProxyEnv = {};
+		return;
+	}
+	try {
+		const result = await session.defaultSession.resolveProxy(
+			SYSTEM_PROXY_PROBE_URL,
+		);
+		systemProxyEnv = proxyEnvFromPacResult(result);
+	} catch {
+		systemProxyEnv = {};
+	}
+}
+
+function broadcastChanged(settings: ProxySettings): void {
+	for (const win of BrowserWindow.getAllWindows()) {
+		win.webContents.send(IpcChannels.proxy.changed, settings);
+	}
+}
+
+export function getProxySettings(): ProxySettings {
+	return { ...currentSettings };
+}
+
+/** Explicit app setting wins: clear inherited proxy vars, then re-add per mode. */
+export function withProxyEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const next = { ...env };
+	for (const key of PROXY_ENV_KEYS) delete next[key];
+	if (currentSettings.mode === "custom") {
+		Object.assign(next, proxyEnvFromUrl(currentSettings.url));
+	} else if (currentSettings.mode === "system") {
+		Object.assign(next, systemProxyEnv);
+	}
+	return next;
+}
+
+/** Load persisted settings and apply them; call once after app ready. */
+export async function initProxy(): Promise<void> {
+	currentSettings = readSettingsFromDisk();
+	try {
+		await applyProxySettings(currentSettings);
+		await refreshSystemProxyEnv();
+	} catch (err) {
+		console.warn("[proxy] failed to apply settings on startup", err);
+	}
+}
+
+export function registerProxyIpc(): void {
+	ipcMain.handle(IpcChannels.proxy.get, () => getProxySettings());
+
+	ipcMain.handle(
+		IpcChannels.proxy.set,
+		async (_event, payload: Partial<ProxySettings> | null | undefined) => {
+			const mode = PROXY_MODES.includes(payload?.mode as ProxySettings["mode"])
+				? (payload?.mode as ProxySettings["mode"])
+				: DEFAULT_PROXY_SETTINGS.mode;
+			const url = typeof payload?.url === "string" ? payload.url.trim() : "";
+			if (mode === "custom" && !normalizeProxyUrl(url)) {
+				throw new Error("Invalid proxy URL");
+			}
+			const next: ProxySettings = {
+				mode,
+				url: mode === "custom" ? (normalizeProxyUrl(url) ?? "") : url,
+			};
+			currentSettings = next;
+			try {
+				writeSettingsToDisk(next);
+			} catch (err) {
+				console.warn("[proxy] failed to persist settings", err);
+			}
+			await applyProxySettings(next);
+			await refreshSystemProxyEnv();
+			broadcastChanged(next);
+			return getProxySettings();
+		},
+	);
+}

--- a/src/main/session-broker.ts
+++ b/src/main/session-broker.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { existsSync } from "node:fs";
-import type { WorkerInbound, WorkerOutbound } from "../shared/agent-worker-messages";
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+} from "../shared/agent-worker-messages";
 import type { DesktopSecuritySettings } from "../shared/desktop-security";
 import type {
   AgentCommand,
@@ -9,12 +12,16 @@ import type {
   ContextUsageSegmentId,
   SessionStatus,
   SessionSummary,
-  type SessionImageCacheResult,
-  type SessionImageCacheSource,
+  SessionImageCacheResult,
+  SessionImageCacheSource,
 } from "../shared/protocol";
 import { IDLE_WORKER_DESTROY_MS } from "./worker-lifecycle";
 import { listSessionsForCwd, purgeWorkspaceSessionDir } from "./session-list";
-import { clearSessionConversation, deleteSessionFile, invalidateSessionHistoryCache } from "./session-history";
+import {
+  clearSessionConversation,
+  deleteSessionFile,
+  invalidateSessionHistoryCache,
+} from "./session-history";
 import { appendChatMeta } from "./session-chat-meta";
 import type { ChatMessageTag } from "../shared/chat-meta";
 import { downloadImageToCache, saveImageDataUrl } from "./session-image-cache";
@@ -68,7 +75,12 @@ export type WorkerHandle = {
 export type SpawnWorker = (
   cwd: string,
   filePath?: string,
-) => Promise<{ worker: WorkerHandle; id: string; filePath: string; cwd: string }>;
+) => Promise<{
+  worker: WorkerHandle;
+  id: string;
+  filePath: string;
+  cwd: string;
+}>;
 
 /** Allocate session id + jsonl without spawning the Pi agent worker. */
 export type AllocateSession = (cwd: string) => Promise<{
@@ -80,16 +92,25 @@ export type AllocateSession = (cwd: string) => Promise<{
 export type SessionBroker = {
   createSession: (cwd: string) => Promise<SessionSummary>;
   listSessions: (cwd: string) => Promise<SessionSummary[]>;
-  openSession: (sessionId: string, cwd: string) => Promise<SessionSummary | null>;
+  openSession: (
+    sessionId: string,
+    cwd: string,
+  ) => Promise<SessionSummary | null>;
   closeSession: (sessionId: string) => Promise<void>;
   send: (sessionId: string, command: AgentCommand) => Promise<unknown>;
   /**
    * Like send, but never cold-starts a worker. Returns `undefined` when no worker is alive
    * (used for UI sync without waking the Pi agent).
    */
-  trySend: (sessionId: string, command: AgentCommand) => Promise<unknown | undefined>;
+  trySend: (
+    sessionId: string,
+    command: AgentCommand,
+  ) => Promise<unknown | undefined>;
   /** Fire-and-forget worker message (no pending-command tracking). */
-  sendRaw: (sessionId: string, msg: WorkerInbound) => Promise<WorkerOutbound | null>;
+  sendRaw: (
+    sessionId: string,
+    msg: WorkerInbound,
+  ) => Promise<WorkerOutbound | null>;
   /**
    * Send to a live worker only — never cold-starts via ensureWorker/spawn.
    * Returns false when no worker is alive for the session.
@@ -109,7 +130,9 @@ export type SessionBroker = {
   clearContext: (sessionId: string, cwd: string) => Promise<void>;
   notifyWorkersReloadModels: () => Promise<void>;
   /** Hot-reload desktopSecurity into live workers (no restart). */
-  notifyWorkersReloadSecurity: (desktopSecurity: DesktopSecuritySettings) => Promise<void>;
+  notifyWorkersReloadSecurity: (
+    desktopSecurity: DesktopSecuritySettings,
+  ) => Promise<void>;
   /** Delete one cached image file (user removed it from the editor). */
   deleteCachedImage: (sessionId: string, cachePath: string) => void;
   /** Cache a pasted / URL image into the session's attachment folder. */
@@ -166,7 +189,8 @@ export function createSessionBroker(deps: {
   hasActiveRuns?: (sessionId: string) => boolean;
 }): SessionBroker {
   const idleDestroyMs = deps.idleDestroyMs ?? IDLE_WORKER_DESTROY_MS;
-  const allocateSession = deps.allocateSession ?? (async (cwd: string) => allocateSessionOnDisk(cwd));
+  const allocateSession =
+    deps.allocateSession ?? (async (cwd: string) => allocateSessionOnDisk(cwd));
   const sessions = new Map<string, SessionRecord>();
   const listeners = new Set<(event: AgentEvent) => void>();
 
@@ -255,7 +279,10 @@ export function createSessionBroker(deps: {
         // Total event-loop silence (no pong, no events) past the stall window
         // means the loop is wedged, not slow. Emit once — the renderer decides
         // whether to abort + restart; we never kill a mid-turn worker here.
-        if (Date.now() - current.lastAliveAt >= STALL_EMIT_MS && !current.stallEmitted) {
+        if (
+          Date.now() - current.lastAliveAt >= STALL_EMIT_MS &&
+          !current.stallEmitted
+        ) {
           current.stallEmitted = true;
           emit({ type: "worker_stall", sessionId });
         }
@@ -360,7 +387,9 @@ export function createSessionBroker(deps: {
       spawned.worker.kill();
       throw new Error(
         `session id mismatch: expected ${sessionId}, got ${spawned.id}` +
-          (filePath ? ` (file: ${filePath})` : " (new session had no file yet)"),
+          (filePath
+            ? ` (file: ${filePath})`
+            : " (new session had no file yet)"),
       );
     }
     rec.worker = spawned.worker;
@@ -383,7 +412,8 @@ export function createSessionBroker(deps: {
   function trimIdleWorkers(): void {
     const idle: { sessionId: string; spawnedAt: number }[] = [];
     for (const [id, rec] of sessions) {
-      if (!rec.worker || rec.summary.status !== "idle" || rec.workerPromise) continue;
+      if (!rec.worker || rec.summary.status !== "idle" || rec.workerPromise)
+        continue;
       if (deps.hasActiveRuns?.(id)) continue;
       idle.push({ sessionId: id, spawnedAt: rec.spawnedAt });
     }
@@ -473,7 +503,10 @@ export function createSessionBroker(deps: {
           ttftSteps?: unknown;
           tokensPerSecond?: unknown;
         };
-        if (ev.type === "context_usage" && typeof ev.contextWindow === "number") {
+        if (
+          ev.type === "context_usage" &&
+          typeof ev.contextWindow === "number"
+        ) {
           const segments = Array.isArray(ev.segments)
             ? ev.segments
                 .map((row): ContextUsageSegment | null => {
@@ -485,8 +518,12 @@ export function createSessionBroker(deps: {
                   ) {
                     return null;
                   }
-                  if (typeof s.tokens !== "number" || s.tokens <= 0) return null;
-                  return { id: s.id as ContextUsageSegmentId, tokens: s.tokens };
+                  if (typeof s.tokens !== "number" || s.tokens <= 0)
+                    return null;
+                  return {
+                    id: s.id as ContextUsageSegmentId,
+                    tokens: s.tokens,
+                  };
                 })
                 .filter((s): s is ContextUsageSegment => Boolean(s))
             : null;
@@ -498,17 +535,30 @@ export function createSessionBroker(deps: {
               contextWindow: ev.contextWindow,
               percent: typeof ev.percent === "number" ? ev.percent : null,
               toolCalls: typeof ev.toolCalls === "number" ? ev.toolCalls : null,
-              messageCount: typeof ev.messageCount === "number" ? ev.messageCount : null,
+              messageCount:
+                typeof ev.messageCount === "number" ? ev.messageCount : null,
               turns: typeof ev.turns === "number" ? ev.turns : null,
               steps: typeof ev.steps === "number" ? ev.steps : null,
-              inputTokens: typeof ev.inputTokens === "number" ? ev.inputTokens : null,
-              outputTokens: typeof ev.outputTokens === "number" ? ev.outputTokens : null,
-              cacheReadTokens: typeof ev.cacheReadTokens === "number" ? ev.cacheReadTokens : null,
-              cacheWriteTokens: typeof ev.cacheWriteTokens === "number" ? ev.cacheWriteTokens : null,
-              llmDurationMs: typeof ev.llmDurationMs === "number" ? ev.llmDurationMs : null,
+              inputTokens:
+                typeof ev.inputTokens === "number" ? ev.inputTokens : null,
+              outputTokens:
+                typeof ev.outputTokens === "number" ? ev.outputTokens : null,
+              cacheReadTokens:
+                typeof ev.cacheReadTokens === "number"
+                  ? ev.cacheReadTokens
+                  : null,
+              cacheWriteTokens:
+                typeof ev.cacheWriteTokens === "number"
+                  ? ev.cacheWriteTokens
+                  : null,
+              llmDurationMs:
+                typeof ev.llmDurationMs === "number" ? ev.llmDurationMs : null,
               ttftMs: typeof ev.ttftMs === "number" ? ev.ttftMs : null,
               ttftSteps: typeof ev.ttftSteps === "number" ? ev.ttftSteps : null,
-              tokensPerSecond: typeof ev.tokensPerSecond === "number" ? ev.tokensPerSecond : null,
+              tokensPerSecond:
+                typeof ev.tokensPerSecond === "number"
+                  ? ev.tokensPerSecond
+                  : null,
               segments,
             },
           });
@@ -544,7 +594,10 @@ export function createSessionBroker(deps: {
         rec.workerPromise = null;
         if (/^worker exited \(0\)$/i.test(errText.trim())) {
           deps.onSessionWorkerGone?.(sessionId);
-          if (rec.summary.status === "running" || rec.summary.status === "stuck") {
+          if (
+            rec.summary.status === "running" ||
+            rec.summary.status === "stuck"
+          ) {
             setStatus(sessionId, "idle");
           }
           return;
@@ -569,7 +622,10 @@ export function createSessionBroker(deps: {
         rec.pendingCommands.delete(msg.id);
         if (msg.error) {
           // Prompt/command failure ends the turn — UI should not stay "running".
-          setStatus(sessionId, pending.command.type === "prompt" ? "idle" : "error");
+          setStatus(
+            sessionId,
+            pending.command.type === "prompt" ? "idle" : "error",
+          );
           emit({ type: "prompt_error", sessionId, errorMessage: msg.error });
           pending.reject(new Error(msg.error));
           return;
@@ -627,30 +683,14 @@ export function createSessionBroker(deps: {
     return { ...summary };
   }
 
-  function registerWorkerSession(
-    id: string,
-    cwd: string,
-    filePath: string,
-    worker: WorkerHandle,
-    meta?: Partial<Pick<SessionSummary, "name" | "firstMessage" | "modified">>,
-  ): SessionSummary {
-    const summary = registerSessionShell(id, cwd, filePath, meta);
-    const rec = sessions.get(id);
-    if (!rec) return summary;
-    rec.worker = worker;
-    rec.summary.filePath = filePath;
-    rec.lastAliveAt = Date.now();
-    attachWorker(id, worker);
-    startHeartbeat(id);
-    scheduleIdleDestroy(id);
-    emit({ type: "connected", sessionId: id });
-    return { ...rec.summary };
-  }
-
   async function createSession(cwd: string): Promise<SessionSummary> {
     // Fast path: disk session only. Pi agent worker starts on first send/command.
     const allocated = await allocateSession(cwd);
-    return registerSessionShell(allocated.id, allocated.cwd, allocated.filePath);
+    return registerSessionShell(
+      allocated.id,
+      allocated.cwd,
+      allocated.filePath,
+    );
   }
 
   async function listSessions(cwd: string): Promise<SessionSummary[]> {
@@ -677,11 +717,15 @@ export function createSessionBroker(deps: {
             ? rec.summary.modified > existing.modified
               ? rec.summary.modified
               : existing.modified
-            : (rec.summary.modified ?? existing?.modified ?? new Date().toISOString()),
+            : (rec.summary.modified ??
+              existing?.modified ??
+              new Date().toISOString()),
         status: rec.summary.status,
       });
     }
-    return [...merged.values()].sort((a, b) => b.modified.localeCompare(a.modified));
+    return [...merged.values()].sort((a, b) =>
+      b.modified.localeCompare(a.modified),
+    );
   }
 
   function deleteCachedImage(sessionId: string, cachePath: string): void {
@@ -691,7 +735,6 @@ export function createSessionBroker(deps: {
     deleteImageFile(filePath, cachePath);
   }
 
-
   async function cacheImage(
     sessionId: string,
     source: SessionImageCacheSource,
@@ -699,11 +742,23 @@ export function createSessionBroker(deps: {
     const rec = sessions.get(sessionId);
     const filePath = rec?.summary.filePath;
     if (!filePath) throw new Error(`session not found: ${sessionId}`);
-    if ("url" in source && typeof source.url === "string" && source.url.trim()) {
+    if (
+      "url" in source &&
+      typeof source.url === "string" &&
+      source.url.trim()
+    ) {
       const saved = await downloadImageToCache(filePath, source.url.trim());
-      return { filePath: saved.filePath, mimeType: saved.mimeType, dataUrl: saved.dataUrl };
+      return {
+        filePath: saved.filePath,
+        mimeType: saved.mimeType,
+        dataUrl: saved.dataUrl,
+      };
     }
-    if ("dataUrl" in source && typeof source.dataUrl === "string" && source.dataUrl.trim()) {
+    if (
+      "dataUrl" in source &&
+      typeof source.dataUrl === "string" &&
+      source.dataUrl.trim()
+    ) {
       const saved = saveImageDataUrl(filePath, source.dataUrl.trim());
       return {
         filePath: saved.filePath,
@@ -735,12 +790,16 @@ export function createSessionBroker(deps: {
     const rec = sessions.get(sessionId);
     if (!rec) return null;
     if (patch.name !== undefined) rec.summary.name = patch.name;
-    if (patch.firstMessage !== undefined) rec.summary.firstMessage = patch.firstMessage;
+    if (patch.firstMessage !== undefined)
+      rec.summary.firstMessage = patch.firstMessage;
     if (patch.modified !== undefined) rec.summary.modified = patch.modified;
     return { ...rec.summary };
   }
 
-  async function openSession(sessionId: string, cwd: string): Promise<SessionSummary | null> {
+  async function openSession(
+    sessionId: string,
+    cwd: string,
+  ): Promise<SessionSummary | null> {
     const live = sessions.get(sessionId);
     if (live) {
       // Re-sync title/first message from disk in the background (non-blocking).
@@ -751,7 +810,8 @@ export function createSessionBroker(deps: {
         const target = disk.find((s) => s.id === sessionId);
         if (target) {
           if (target.name?.trim()) live.summary.name = target.name;
-          if (target.firstMessage?.trim()) live.summary.firstMessage = target.firstMessage;
+          if (target.firstMessage?.trim())
+            live.summary.firstMessage = target.firstMessage;
           live.summary.modified = target.modified;
           if (target.filePath) live.summary.filePath = target.filePath;
         }
@@ -781,7 +841,10 @@ export function createSessionBroker(deps: {
     return summary;
   }
 
-  async function disconnectWorker(sessionId: string, reason: string): Promise<void> {
+  async function disconnectWorker(
+    sessionId: string,
+    reason: string,
+  ): Promise<void> {
     const rec = sessions.get(sessionId);
     if (!rec?.worker) {
       if (rec) {
@@ -810,19 +873,6 @@ export function createSessionBroker(deps: {
       // ignore
     }
     deps.onSessionWorkerGone?.(sessionId);
-  }
-
-  async function teardownWorker(sessionId: string, code: number | null): Promise<void> {
-    const rec = sessions.get(sessionId);
-    if (!rec) {
-      return;
-    }
-    clearIdleDestroyTimer(rec);
-    stopHeartbeat(rec);
-    if (rec.worker) {
-      rec.worker.kill();
-    }
-    emit({ type: "worker_exit", sessionId, code });
   }
 
   async function closeSession(sessionId: string): Promise<void> {
@@ -866,7 +916,9 @@ export function createSessionBroker(deps: {
     opts?: { coldStart?: boolean },
   ): Promise<unknown | undefined> {
     const coldStart = opts?.coldStart !== false;
-    const rec = coldStart ? await ensureWorker(sessionId) : sessions.get(sessionId);
+    const rec = coldStart
+      ? await ensureWorker(sessionId)
+      : sessions.get(sessionId);
     const worker = rec?.worker;
     if (!worker) {
       if (!coldStart) return undefined;
@@ -982,7 +1034,9 @@ export function createSessionBroker(deps: {
   async function restartWorkersForCwd(cwd: string): Promise<void> {
     const resolved = path.resolve(cwd);
     const ids = [...sessions.entries()]
-      .filter(([, rec]) => path.resolve(rec.cwd) === resolved && rec.worker !== null)
+      .filter(
+        ([, rec]) => path.resolve(rec.cwd) === resolved && rec.worker !== null,
+      )
       .map(([id]) => id);
     for (const id of ids) {
       await restartWorker(id);
@@ -1014,7 +1068,8 @@ export function createSessionBroker(deps: {
       ([, rec]) => path.resolve(rec.cwd) === resolved,
     );
     for (const [id, rec] of live) {
-      if (rec.summary.filePath) invalidateSessionHistoryCache(rec.summary.filePath);
+      if (rec.summary.filePath)
+        invalidateSessionHistoryCache(rec.summary.filePath);
       await disconnectWorker(id, "workspace purged");
       sessions.delete(id);
       emit({ type: "worker_exit", sessionId: id, code: 0 });

--- a/src/main/session-history.ts
+++ b/src/main/session-history.ts
@@ -1,15 +1,31 @@
 import fs from "node:fs/promises";
-import type { SessionHistoryMessage, SessionHistoryPage } from "../shared/protocol";
+import { rmSync } from "node:fs";
+import type {
+  SessionHistoryMessage,
+  SessionHistoryPage,
+} from "../shared/protocol";
+import { sessionTimingPath } from "../shared/session-timing";
 import { deleteChatMeta, readChatMeta } from "./session-chat-meta";
 import { deleteImageCache } from "./session-image-cache";
 import {
   parseSessionHistoryJsonl,
   parseSessionHistoryPageFromJsonl,
 } from "./session-history-parse";
-import { parseHistoryOffMain, parseHistoryPageOffMain } from "./session-history-offload";
+import {
+  parseHistoryOffMain,
+  parseHistoryPageOffMain,
+} from "./session-history-offload";
 
 /** Default page size for chat UI history (tail / older pages). Disk jsonl stays full (shared with Pi CLI). */
 export const SESSION_HISTORY_PAGE_SIZE = 30;
+
+function deleteTimingMeta(filePath: string): void {
+  try {
+    rmSync(sessionTimingPath(filePath), { force: true });
+  } catch {
+    // ignore
+  }
+}
 
 type HistoryCacheEntry = {
   mtimeMs: number;
@@ -63,10 +79,10 @@ function writePageCache(
 ): void {
   const key = pageCacheKey(limit, beforeId);
   const rows = pageCache.get(filePath) ?? [];
-  const next = [{ mtimeMs, key, page }, ...rows.filter((r) => r.key !== key)].slice(
-    0,
-    PAGE_CACHE_PER_FILE,
-  );
+  const next = [
+    { mtimeMs, key, page },
+    ...rows.filter((r) => r.key !== key),
+  ].slice(0, PAGE_CACHE_PER_FILE);
   pageCache.set(filePath, next);
   if (pageCache.size > 32) {
     const first = pageCache.keys().next().value;
@@ -74,7 +90,9 @@ function writePageCache(
   }
 }
 
-async function loadAllHistoryMessages(filePath: string): Promise<SessionHistoryMessage[]> {
+async function loadAllHistoryMessages(
+  filePath: string,
+): Promise<SessionHistoryMessage[]> {
   let st: { mtimeMs: number };
   try {
     st = await fs.stat(filePath);
@@ -91,7 +109,10 @@ async function loadAllHistoryMessages(filePath: string): Promise<SessionHistoryM
     // Heavy JSONL parse off the main process (large sessions freeze every window).
     messages = await parseHistoryOffMain(filePath);
   } catch (err) {
-    console.warn("[pi-desktop] history worker failed; falling back on main", err);
+    console.warn(
+      "[pi-desktop] history worker failed; falling back on main",
+      err,
+    );
     let raw: string;
     try {
       raw = await fs.readFile(filePath, "utf8");
@@ -110,7 +131,9 @@ async function loadAllHistoryMessages(filePath: string): Promise<SessionHistoryM
 }
 
 /** Full leaf-path history (tests / callers that need everything). */
-export async function readSessionHistoryMessages(filePath: string): Promise<SessionHistoryMessage[]> {
+export async function readSessionHistoryMessages(
+  filePath: string,
+): Promise<SessionHistoryMessage[]> {
   return loadAllHistoryMessages(filePath);
 }
 
@@ -126,7 +149,10 @@ export async function readSessionHistoryPage(
   filePath: string,
   opts?: { limit?: number; beforeId?: string | null },
 ): Promise<SessionHistoryPage> {
-  const limit = Math.max(1, Math.min(200, opts?.limit ?? SESSION_HISTORY_PAGE_SIZE));
+  const limit = Math.max(
+    1,
+    Math.min(200, opts?.limit ?? SESSION_HISTORY_PAGE_SIZE),
+  );
   const beforeId = opts?.beforeId?.trim() || null;
 
   let st: { mtimeMs: number };
@@ -174,7 +200,10 @@ export async function readSessionHistoryPage(
   try {
     page = await parseHistoryPageOffMain(filePath, { limit, beforeId });
   } catch (err) {
-    console.warn("[pi-desktop] history page worker failed; falling back on main", err);
+    console.warn(
+      "[pi-desktop] history page worker failed; falling back on main",
+      err,
+    );
     let raw: string;
     try {
       raw = await fs.readFile(filePath, "utf8");
@@ -193,8 +222,11 @@ export async function readSessionHistoryPage(
 }
 
 /** Drop conversation entries; keep session header + metadata (name, model, thinking). */
-export async function clearSessionConversation(filePath: string): Promise<void> {
+export async function clearSessionConversation(
+  filePath: string,
+): Promise<void> {
   deleteChatMeta(filePath);
+  deleteTimingMeta(filePath);
   let raw: string;
   try {
     raw = await fs.readFile(filePath, "utf8");
@@ -242,6 +274,7 @@ export async function clearSessionConversation(filePath: string): Promise<void> 
 export async function deleteSessionFile(filePath: string): Promise<void> {
   invalidateSessionHistoryCache(filePath);
   deleteChatMeta(filePath);
+  deleteTimingMeta(filePath);
   deleteImageCache(filePath);
   await fs.unlink(filePath);
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -56,6 +56,7 @@ import type {
 	GitConflictContentResult,
 	GitOpResult,
 } from "../shared/git-types";
+import type { ProxySettings } from "../shared/proxy";
 export type AppInfo = {
 	version: string;
 	githubUrl: string;
@@ -85,8 +86,16 @@ declare const api: {
 		getStatus: () => Promise<LanConsoleStatus>;
 		setEnabled: (enabled: boolean) => Promise<LanConsoleStatus>;
 		setPort: (port: number) => Promise<LanConsoleStatus>;
-		setCredentials: (username: string, password: string) => Promise<LanConsoleStatus>;
+		setCredentials: (
+			username: string,
+			password: string,
+		) => Promise<LanConsoleStatus>;
 		setPreferredIp: (ip: string) => Promise<LanConsoleStatus>;
+	};
+	proxy: {
+		get: () => Promise<ProxySettings>;
+		set: (settings: ProxySettings) => Promise<ProxySettings>;
+		onChanged: (callback: (settings: ProxySettings) => void) => () => void;
 	};
 	window: {
 		platform: () => Promise<NodeJS.Platform>;
@@ -175,9 +184,7 @@ declare const api: {
 			ok: boolean;
 			reason?: string;
 		}>;
-		onExtensionUi: (
-			callback: (payload: ExtensionUiEvent) => void,
-		) => () => void;
+		onExtensionUi: (callback: (payload: ExtensionUiEvent) => void) => () => void;
 		extensionUiReply: (payload: ExtensionUiReply) => Promise<{
 			ok: boolean;
 			reason?: string;
@@ -482,9 +489,7 @@ declare const api: {
 				subject: string;
 			}[];
 		}>;
-		conflictContent: (
-			relativePath: string,
-		) => Promise<GitConflictContentResult>;
+		conflictContent: (relativePath: string) => Promise<GitConflictContentResult>;
 		resolveConflict: (payload: {
 			relativePath: string;
 			content: string;
@@ -651,9 +656,7 @@ declare const api: {
 		streamPush: (pcm: Int16Array) => Promise<void>;
 		streamStop: () => Promise<AsrStatus>;
 		onStreamEvent: (callback: (event: AsrStreamEvent) => void) => () => void;
-		onProgress: (
-			callback: (progress: AsrInstallProgress) => void,
-		) => () => void;
+		onProgress: (callback: (progress: AsrInstallProgress) => void) => () => void;
 		setWakeHotkey: (accel: string) => Promise<AsrStatus>;
 		setResidentModel: (enabled: boolean) => Promise<AsrStatus>;
 		setWakeEnabled: (enabled: boolean) => Promise<AsrStatus>;
@@ -674,9 +677,7 @@ declare const api: {
 		uninstall: () => Promise<TtsStatus>;
 		speak: (text: string) => Promise<TtsSpeakResult>;
 		stop: () => Promise<TtsStatus>;
-		onProgress: (
-			callback: (progress: TtsInstallProgress) => void,
-		) => () => void;
+		onProgress: (callback: (progress: TtsInstallProgress) => void) => () => void;
 		onSpeaking: (
 			callback: (payload: { speaking: boolean }) => void,
 		) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,8 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
 import type {
-	AgentCommand, LanConsoleStatus,
+	AgentCommand,
+	LanConsoleStatus,
 	AgentEvent,
 	ElementCitation,
 	SessionHistoryMessage,
@@ -23,6 +24,7 @@ import type {
 } from "../shared/model-discover";
 import type { PreviewResult } from "../shared/preview-types";
 import type {
+	AsrCloudConfig,
 	AsrInstallProgress,
 	AsrStatus,
 	AsrStreamEvent,
@@ -58,6 +60,7 @@ import type {
 	GitConflictContentResult,
 	GitOpResult,
 } from "../shared/git-types";
+import type { ProxySettings } from "../shared/proxy";
 
 export type AppInfo = {
 	version: string;
@@ -91,11 +94,19 @@ const api = {
 	},
 	lanConsole: {
 		getStatus: () =>
-			ipcRenderer.invoke(IpcChannels.lanConsole.getStatus) as Promise<LanConsoleStatus>,
+			ipcRenderer.invoke(
+				IpcChannels.lanConsole.getStatus,
+			) as Promise<LanConsoleStatus>,
 		setEnabled: (enabled: boolean) =>
-			ipcRenderer.invoke(IpcChannels.lanConsole.setEnabled, enabled) as Promise<LanConsoleStatus>,
+			ipcRenderer.invoke(
+				IpcChannels.lanConsole.setEnabled,
+				enabled,
+			) as Promise<LanConsoleStatus>,
 		setPort: (port: number) =>
-			ipcRenderer.invoke(IpcChannels.lanConsole.setPort, port) as Promise<LanConsoleStatus>,
+			ipcRenderer.invoke(
+				IpcChannels.lanConsole.setPort,
+				port,
+			) as Promise<LanConsoleStatus>,
 		setCredentials: (username: string, password: string) =>
 			ipcRenderer.invoke(
 				IpcChannels.lanConsole.setCredentials,
@@ -103,13 +114,33 @@ const api = {
 				String(password ?? ""),
 			) as Promise<LanConsoleStatus>,
 		setPreferredIp: (ip: string) =>
-			ipcRenderer.invoke(IpcChannels.lanConsole.setPreferredIp, String(ip ?? "")) as Promise<LanConsoleStatus>,
+			ipcRenderer.invoke(
+				IpcChannels.lanConsole.setPreferredIp,
+				String(ip ?? ""),
+			) as Promise<LanConsoleStatus>,
+	},
+	proxy: {
+		get: () =>
+			ipcRenderer.invoke(IpcChannels.proxy.get) as Promise<ProxySettings>,
+		set: (settings: ProxySettings) =>
+			ipcRenderer.invoke(
+				IpcChannels.proxy.set,
+				settings,
+			) as Promise<ProxySettings>,
+		onChanged: (callback: (settings: ProxySettings) => void) => {
+			const listener = (
+				_event: Electron.IpcRendererEvent,
+				settings: ProxySettings,
+			) => callback(settings);
+			ipcRenderer.on(IpcChannels.proxy.changed, listener);
+			return () => {
+				ipcRenderer.removeListener(IpcChannels.proxy.changed, listener);
+			};
+		},
 	},
 	window: {
 		platform: () =>
-			ipcRenderer.invoke(
-				IpcChannels.window.platform,
-			) as Promise<NodeJS.Platform>,
+			ipcRenderer.invoke(IpcChannels.window.platform) as Promise<NodeJS.Platform>,
 		minimize: () =>
 			ipcRenderer.invoke(IpcChannels.window.minimize) as Promise<void>,
 		maximize: () =>
@@ -125,15 +156,9 @@ const api = {
 				source,
 			) as Promise<void>,
 		setChromeTheme: (mode: "light" | "dark") =>
-			ipcRenderer.invoke(
-				IpcChannels.window.setChromeTheme,
-				mode,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.window.setChromeTheme, mode) as Promise<void>,
 		setUiLocale: (locale: "zh-CN" | "en") =>
-			ipcRenderer.invoke(
-				IpcChannels.window.setUiLocale,
-				locale,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.window.setUiLocale, locale) as Promise<void>,
 		requestMediaAccess: (kind: "microphone" | "camera") =>
 			ipcRenderer.invoke(
 				IpcChannels.window.requestMediaAccess,
@@ -182,8 +207,7 @@ const api = {
 			ipcRenderer.invoke(IpcChannels.workspace.openPath, root) as Promise<
 				string | null
 			>,
-		clear: () =>
-			ipcRenderer.invoke(IpcChannels.workspace.clear) as Promise<null>,
+		clear: () => ipcRenderer.invoke(IpcChannels.workspace.clear) as Promise<null>,
 		removeRecent: (root: string) =>
 			ipcRenderer.invoke(IpcChannels.workspace.removeRecent, root) as Promise<{
 				root: string | null;
@@ -221,10 +245,7 @@ const api = {
 				cwd,
 			) as Promise<SessionSummary | null>,
 		close: (sessionId: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.sessions.close,
-				sessionId,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.sessions.close, sessionId) as Promise<void>,
 		command: (sessionId: string, command: AgentCommand) =>
 			ipcRenderer.invoke(
 				IpcChannels.sessions.command,
@@ -273,10 +294,7 @@ const api = {
 				text,
 				tags,
 			),
-		cacheImage: (
-			sessionId: string,
-			source: { dataUrl?: string; url?: string },
-		) =>
+		cacheImage: (sessionId: string, source: { dataUrl?: string; url?: string }) =>
 			ipcRenderer.invoke(
 				IpcChannels.sessions.cacheImage,
 				sessionId,
@@ -314,10 +332,8 @@ const api = {
 			};
 		},
 		onEvent: (callback: (event: AgentEvent) => void) => {
-			const listener = (
-				_event: Electron.IpcRendererEvent,
-				payload: AgentEvent,
-			) => callback(payload);
+			const listener = (_event: Electron.IpcRendererEvent, payload: AgentEvent) =>
+				callback(payload);
 			ipcRenderer.on(IpcChannels.sessions.event, listener);
 			return () => {
 				ipcRenderer.removeListener(IpcChannels.sessions.event, listener);
@@ -352,10 +368,7 @@ const api = {
 			};
 		},
 		askUserReply: (payload: AskUserAskReply) =>
-			ipcRenderer.invoke(
-				IpcChannels.sessions.askUserReply,
-				payload,
-			) as Promise<{
+			ipcRenderer.invoke(IpcChannels.sessions.askUserReply, payload) as Promise<{
 				ok: boolean;
 				reason?: string;
 			}>,
@@ -435,15 +448,9 @@ const api = {
 				destRelativeDir,
 			) as Promise<string>,
 		delete: (relativePath: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.files.delete,
-				relativePath,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.files.delete, relativePath) as Promise<void>,
 		reveal: (relativePath: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.files.reveal,
-				relativePath,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.files.reveal, relativePath) as Promise<void>,
 	},
 	fs: {
 		watch: (root: string) =>
@@ -520,11 +527,7 @@ const api = {
 				| { ok: false; message: string; code: string }
 			>,
 		logFile: (relativePath: string, limit?: number) =>
-			ipcRenderer.invoke(
-				IpcChannels.git.logFile,
-				relativePath,
-				limit,
-			) as Promise<{
+			ipcRenderer.invoke(IpcChannels.git.logFile, relativePath, limit) as Promise<{
 				entries: {
 					hash: string;
 					shortHash: string;
@@ -535,10 +538,9 @@ const api = {
 			}>,
 
 		showCommitFiles: (commitHash: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.git.showCommitFiles,
-				commitHash,
-			) as Promise<{ files: { status: string; path: string }[] }>,
+			ipcRenderer.invoke(IpcChannels.git.showCommitFiles, commitHash) as Promise<{
+				files: { status: string; path: string }[];
+			}>,
 		resetToCommit: (commitHash: string, mode: "soft" | "hard") =>
 			ipcRenderer.invoke(
 				IpcChannels.git.resetToCommit,
@@ -572,10 +574,7 @@ const api = {
 			relativePath: string;
 			commitHash: string;
 		}) =>
-			ipcRenderer.invoke(
-				IpcChannels.git.restoreFileToCommit,
-				payload,
-			) as Promise<
+			ipcRenderer.invoke(IpcChannels.git.restoreFileToCommit, payload) as Promise<
 				| { ok: true; message?: string }
 				| { ok: false; message: string; code: string }
 			>,
@@ -740,10 +739,7 @@ const api = {
 		set: (payload: ModelsSetPayload) =>
 			ipcRenderer.invoke(IpcChannels.models.set, payload) as Promise<void>,
 		clearKey: (provider: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.models.clearKey,
-				provider,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.models.clearKey, provider) as Promise<void>,
 		test: () =>
 			ipcRenderer.invoke(IpcChannels.models.test) as Promise<
 				ModelsGetResult["available"]
@@ -778,9 +774,7 @@ const api = {
 				content,
 			) as Promise<void>,
 		pickFile: () =>
-			ipcRenderer.invoke(IpcChannels.preview.pickFile) as Promise<
-				string | null
-			>,
+			ipcRenderer.invoke(IpcChannels.preview.pickFile) as Promise<string | null>,
 	},
 	browser: {
 		startSelect: (webContentsId: number) =>
@@ -840,10 +834,7 @@ const api = {
 				ok: boolean;
 			}>,
 		openExternal: (url: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.browser.openExternal,
-				url,
-			) as Promise<void>,
+			ipcRenderer.invoke(IpcChannels.browser.openExternal, url) as Promise<void>,
 		onOpenTab: (
 			callback: (payload: { requestId: string; url: string | null }) => void,
 		) => {
@@ -873,10 +864,7 @@ const api = {
 			) => callback(payload);
 			ipcRenderer.on(IpcChannels.browser.elementSelected, listener);
 			return () => {
-				ipcRenderer.removeListener(
-					IpcChannels.browser.elementSelected,
-					listener,
-				);
+				ipcRenderer.removeListener(IpcChannels.browser.elementSelected, listener);
 			};
 		},
 		onElementScreenshot: (callback: (dataUrl: string) => void) => {
@@ -886,20 +874,14 @@ const api = {
 			};
 			ipcRenderer.on(IpcChannels.browser.elementScreenshot, listener);
 			return () => {
-				ipcRenderer.removeListener(
-					IpcChannels.browser.elementScreenshot,
-					listener,
-				);
+				ipcRenderer.removeListener(IpcChannels.browser.elementScreenshot, listener);
 			};
 		},
 		onSelectCancelled: (callback: () => void) => {
 			const listener = () => callback();
 			ipcRenderer.on(IpcChannels.browser.selectCancelled, listener);
 			return () => {
-				ipcRenderer.removeListener(
-					IpcChannels.browser.selectCancelled,
-					listener,
-				);
+				ipcRenderer.removeListener(IpcChannels.browser.selectCancelled, listener);
 			};
 		},
 		onToggleEmbeddedDevTools: (callback: () => void) => {
@@ -946,9 +928,7 @@ const api = {
 				filePath,
 			) as Promise<AsrStatus>,
 		reinstallRuntime: () =>
-			ipcRenderer.invoke(
-				IpcChannels.asr.reinstallRuntime,
-			) as Promise<AsrStatus>,
+			ipcRenderer.invoke(IpcChannels.asr.reinstallRuntime) as Promise<AsrStatus>,
 		pickRuntimeArchive: () =>
 			ipcRenderer.invoke(IpcChannels.asr.pickRuntimeArchive) as Promise<
 				string | null
@@ -1015,10 +995,7 @@ const api = {
 				enabled,
 			) as Promise<AsrStatus>,
 		setWakeWords: (raw: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.asr.setWakeWords,
-				raw,
-			) as Promise<AsrStatus>,
+			ipcRenderer.invoke(IpcChannels.asr.setWakeWords, raw) as Promise<AsrStatus>,
 		setBackend: (backend: string) =>
 			ipcRenderer.invoke(
 				IpcChannels.asr.setBackend,
@@ -1060,10 +1037,7 @@ const api = {
 		uninstall: () =>
 			ipcRenderer.invoke(IpcChannels.tts.uninstall) as Promise<TtsStatus>,
 		speak: (text: string) =>
-			ipcRenderer.invoke(
-				IpcChannels.tts.speak,
-				text,
-			) as Promise<TtsSpeakResult>,
+			ipcRenderer.invoke(IpcChannels.tts.speak, text) as Promise<TtsSpeakResult>,
 		stop: () => ipcRenderer.invoke(IpcChannels.tts.stop) as Promise<TtsStatus>,
 		onProgress: (callback: (progress: TtsInstallProgress) => void) => {
 			const listener = (
@@ -1125,9 +1099,7 @@ const api = {
 				skipped: boolean;
 			}>,
 		install: () =>
-			ipcRenderer.invoke(
-				IpcChannels.piCli.install,
-			) as Promise<PiCliInstallResult>,
+			ipcRenderer.invoke(IpcChannels.piCli.install) as Promise<PiCliInstallResult>,
 		skip: () =>
 			ipcRenderer.invoke(IpcChannels.piCli.skip) as Promise<{
 				skipped: boolean;

--- a/src/renderer/components.d.ts
+++ b/src/renderer/components.d.ts
@@ -53,6 +53,7 @@ declare module 'vue' {
     PiCliSetup: typeof import('./src/components/PiCliSetup.vue')['default']
     PreviewTab: typeof import('./src/components/PreviewTab.vue')['default']
     ProviderIcon: typeof import('./src/components/ProviderIcon.vue')['default']
+    ProxySettings: typeof import('./src/components/ProxySettings.vue')['default']
     RightPane: typeof import('./src/components/RightPane.vue')['default']
     RunningTab: typeof import('./src/components/RunningTab.vue')['default']
     SecuritySettings: typeof import('./src/components/SecuritySettings.vue')['default']

--- a/src/renderer/src/components/ProxySettings.vue
+++ b/src/renderer/src/components/ProxySettings.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import {
+  NModal,
+  NRadioGroup,
+  NRadioButton,
+  NInput,
+  NText,
+  NButton,
+  useMessage,
+} from "naive-ui";
+import {
+  normalizeProxyUrl,
+  type ProxyMode,
+} from "../../../shared/proxy";
+import { t } from "@renderer/i18n";
+
+const props = defineProps<{ open: boolean }>();
+const emit = defineEmits<{ close: [] }>();
+
+const message = useMessage();
+
+const mode = ref<ProxyMode>("off");
+const url = ref("");
+let loaded = false;
+
+watch(
+  () => props.open,
+  async (open) => {
+    if (!open) {
+      loaded = false;
+      return;
+    }
+    try {
+      const current = await window.api.proxy.get();
+      mode.value = current.mode;
+      url.value = current.url;
+    } catch {
+    } finally {
+      loaded = true;
+    }
+  },
+);
+
+let applyChain: Promise<void> = Promise.resolve();
+
+function apply(showSuccess = false): void {
+  applyChain = applyChain.then(async () => {
+    try {
+      const applied = await window.api.proxy.set({
+        mode: mode.value,
+        url: url.value.trim(),
+      });
+      mode.value = applied.mode;
+      url.value = applied.url;
+      if (showSuccess) message.success(t.proxyApplied);
+    } catch {
+      message.error(t.proxyInvalidUrl);
+    }
+  });
+}
+
+watch(mode, (next, prev) => {
+  if (!loaded || next === prev) return;
+  if (next === "custom" && !normalizeProxyUrl(url.value)) return;
+  apply(true);
+});
+
+let urlTimer: ReturnType<typeof setTimeout> | undefined;
+watch(url, () => {
+  if (!loaded || mode.value !== "custom") return;
+  clearTimeout(urlTimer);
+  urlTimer = setTimeout(() => {
+    if (normalizeProxyUrl(url.value)) apply();
+  }, 600);
+});
+
+const urlInvalid = computed(
+  () =>
+    mode.value === "custom" &&
+    url.value.trim().length > 0 &&
+    normalizeProxyUrl(url.value) === null,
+);
+</script>
+
+<template>
+  <NModal
+    :show="props.open"
+    preset="card"
+    class="pi-settings-modal"
+    style="width: min(520px, 92vw)"
+    :title="t.proxyTitle"
+    :bordered="false"
+    size="huge"
+    @update:show="(v) => !v && emit('close')"
+  >
+    <div class="modal-scroll">
+      <div class="section">
+        <NRadioGroup v-model:value="mode" size="small">
+          <NRadioButton value="off">{{ t.proxyModeOff }}</NRadioButton>
+          <NRadioButton value="system">{{ t.proxyModeSystem }}</NRadioButton>
+          <NRadioButton value="custom">{{ t.proxyModeCustom }}</NRadioButton>
+        </NRadioGroup>
+      </div>
+
+      <div v-if="mode === 'custom'" class="section" style="margin-top: 16px">
+        <NText strong style="font-size: 13px; display: block; margin-bottom: 6px">
+          {{ t.proxyUrlLabel }}
+        </NText>
+        <NInput
+          v-model:value="url"
+          size="small"
+          :status="urlInvalid ? 'error' : undefined"
+          :placeholder="t.proxyUrlPlaceholder"
+        />
+      </div>
+    </div>
+    <template #footer>
+      <div class="footer">
+        <NButton @click="emit('close')">{{ t.close }}</NButton>
+      </div>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.section {
+  display: flex;
+  flex-direction: column;
+}
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/src/renderer/src/components/TitleBar.vue
+++ b/src/renderer/src/components/TitleBar.vue
@@ -7,6 +7,7 @@ import {
   ColorPaletteOutline,
   ExtensionPuzzleOutline,
   FolderOpenOutline,
+  GlobeOutline,
   InformationCircleOutline,
   LogoGithub,
   MicOutline,
@@ -36,6 +37,7 @@ const AsrSettings = defineAsyncComponent(() => import("@renderer/components/AsrS
 const SecuritySettings = defineAsyncComponent(() => import("@renderer/components/SecuritySettings.vue"));
 const AboutSettings = defineAsyncComponent(() => import("@renderer/components/AboutSettings.vue"));
 const LanConsoleSettings = defineAsyncComponent(() => import("@renderer/components/LanConsoleSettings.vue"));
+const ProxySettings = defineAsyncComponent(() => import("@renderer/components/ProxySettings.vue"));
 
 import UpdateCard from "@renderer/components/UpdateCard.vue";
 import { useWorkspaceStore } from "@renderer/stores/workspace";
@@ -58,6 +60,7 @@ const notifyOpen = ref(false);
 const asrOpen = ref(false);
 const securityOpen = ref(false);
 const aboutOpen = ref(false);
+const proxyOpen = ref(false);
 const lanConsoleOpen = ref(false);
 const lanConsoleEnabled = ref(false);
 
@@ -157,6 +160,11 @@ const settingsOptions: DropdownOption[] = [
     icon: () => h(NIcon, null, { default: () => h(StorefrontOutline) }),
   },
   {
+    label: t.proxyTitle,
+    key: "proxy",
+    icon: () => h(NIcon, null, { default: () => h(GlobeOutline) }),
+  },
+  {
     type: "divider",
     key: "d-about",
   },
@@ -192,6 +200,9 @@ function onSettingsSelect(key: string | number): void {
       break;
     case "market":
       marketOpen.value = true;
+      break;
+    case "proxy":
+      proxyOpen.value = true;
       break;
     case "about":
       aboutOpen.value = true;
@@ -368,6 +379,7 @@ async function onUpdateClick(): Promise<void> {
   <ExtensionsSettings :open="extensionsOpen" @close="extensionsOpen = false" />
   <MarketSettings :open="marketOpen" @close="marketOpen = false" />
   <AboutSettings :open="aboutOpen" @close="aboutOpen = false" />
+  <ProxySettings :open="proxyOpen" @close="proxyOpen = false" />
 </template>
 
 <style scoped>

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -190,8 +190,7 @@ export const en = {
 		"Open a file from the workspace, or click Preview on a tool path in chat",
 	loading: "Loading…",
 	previewUnsupported: "This file type cannot be previewed yet",
-	previewBinary:
-		"This is a binary file and cannot be opened in the text editor",
+	previewBinary: "This is a binary file and cannot be opened in the text editor",
 	previewTruncated: "File truncated to 1.5MB",
 	mdEdit: "Edit",
 	mdPreview: "Preview",
@@ -401,6 +400,14 @@ export const en = {
 	gitErr_unknown: "Git operation failed",
 	appearance: "Appearance",
 	notifyTitle: "Notifications",
+	proxyTitle: "Network proxy",
+	proxyModeOff: "Off",
+	proxyModeSystem: "Auto",
+	proxyModeCustom: "Manual",
+	proxyUrlLabel: "Proxy URL",
+	proxyUrlPlaceholder: "http://127.0.0.1:7890 or socks5://127.0.0.1:1080",
+	proxyApplied: "Proxy settings applied",
+	proxyInvalidUrl: "Invalid proxy URL — use an http / https / socks5 address",
 	notifySound: "Completion sound",
 	notifySoundHint:
 		"Play the built-in chime when a turn finishes (also when focused).",
@@ -482,8 +489,10 @@ export const en = {
 	asrWakeWordsSave: "Save wake words",
 	asrWakeWordsSaved: "Wake words saved",
 	asrWakeListenFail: "Could not start voice wake listening",
-	asrWakeModelNeeded: "Install / prepare the local ASR model first, then enable Voice wake.",
-	asrWakeUnavailable: "Voice wake can't start — check the ASR runtime and microphone.",
+	asrWakeModelNeeded:
+		"Install / prepare the local ASR model first, then enable Voice wake.",
+	asrWakeUnavailable:
+		"Voice wake can't start — check the ASR runtime and microphone.",
 	loadingChatHistory: "Loading chat history…",
 	loadingOlderHistory: "Loading older messages…",
 	scrollForOlderHistory: "Scroll up for older messages",
@@ -627,14 +636,17 @@ export const en = {
 	lanConsoleUsername: "Username",
 	lanConsolePassword: "Password",
 	lanConsoleSaveCreds: "Save",
-	lanConsoleCredsHint: "A 6-hour session token is issued after login; refreshing keeps you logged in.",
+	lanConsoleCredsHint:
+		"A 6-hour session token is issued after login; refreshing keeps you logged in.",
 	lanConsoleCredsRequired: "Username and password required",
 	lanConsoleCredsSaved: "Credentials saved",
 	lanConsoleTitle: "LAN Web Console",
-	lanConsoleEnableHint: "Off by default. When enabled, devices on your LAN can open this machine in a browser to browse workspaces/sessions, chat and use voice recognition (token required).",
+	lanConsoleEnableHint:
+		"Off by default. When enabled, devices on your LAN can open this machine in a browser to browse workspaces/sessions, chat and use voice recognition (token required).",
 	lanConsoleUrl: "Access URL",
 	lanConsoleAddresses: "Addresses",
-	lanConsoleAddressesHint: "This PC may have multiple NICs. If the phone cannot connect, pick the Wi‑Fi / Ethernet 192.168.x.x address.",
+	lanConsoleAddressesHint:
+		"This PC may have multiple NICs. If the phone cannot connect, pick the Wi‑Fi / Ethernet 192.168.x.x address.",
 	lanConsoleRecommended: "Best",
 	lanConsoleToken: "Access token",
 	lanConsoleCopy: "Copy",
@@ -643,7 +655,8 @@ export const en = {
 	lanConsolePort: "Port",
 	lanConsoleSavePort: "Save port",
 	lanConsoleScan: "Scan with your phone",
-	lanConsoleCertHint: "Browsers will warn about the self-signed certificate — choose Continue (HTTPS is required for the microphone).",
+	lanConsoleCertHint:
+		"Browsers will warn about the self-signed certificate — choose Continue (HTTPS is required for the microphone).",
 	lanConsoleDisabledNote: "Disabled. Kept off by default; no port is exposed.",
 	lanConsoleStarted: "LAN web console started",
 	lanConsolePortInvalid: "Invalid port",
@@ -763,9 +776,11 @@ export const en = {
 		"OpenAI-compatible URLs should include /v1 (e.g. https://api.longcat.chat/openai/v1). Do not include /chat/completions.",
 	modelsCustomFetchModels: "Fetch models",
 	modelsCustomFetching: "Fetching…",
-	modelsCustomFetchOk: (n: number) => `Merged ${n} model(s) into draft (not saved yet)`,
+	modelsCustomFetchOk: (n: number) =>
+		`Merged ${n} model(s) into draft (not saved yet)`,
 	modelsCustomFetchFail: "Fetch failed",
-	modelsCustomFetchHint: "Fetch only updates the list below; Save writes to disk.",
+	modelsCustomFetchHint:
+		"Fetch only updates the list below; Save writes to disk.",
 	modelsCustomTest: "Test",
 	modelsCustomTesting: "Testing…",
 	modelsCustomTestOk: (ms: number) => `Connected · ${ms} ms`,
@@ -803,8 +818,7 @@ export const en = {
 		`Delete “${id}” from models.json now? This takes effect immediately.`,
 	modelsCustomDeleted: "Deleted",
 	modelsNeedsKey: "API key required",
-	modelsNothingToAdd:
-		"Nothing to add — all providers may already be configured",
+	modelsNothingToAdd: "Nothing to add — all providers may already be configured",
 	modelsKeyCleared: "API key cleared",
 	modelsSourceEnv: "Environment",
 	modelsSourceRuntime: "Runtime",
@@ -958,8 +972,7 @@ export const en = {
 	sessionIdCopied: "Session ID copied",
 	renameSession: "Rename session",
 	sessionNamePlaceholder: "Session name",
-	selectOrCreateSession:
-		"Select a session on the left, or create one to start.",
+	selectOrCreateSession: "Select a session on the left, or create one to start.",
 	noRecentProjects: "No recent projects",
 
 	// Project trust

--- a/src/renderer/src/i18n/zh-CN.ts
+++ b/src/renderer/src/i18n/zh-CN.ts
@@ -76,8 +76,7 @@ export const zh = {
 		"计划模式：多轮询问后生成 Markdown 计划，确认后停止，不自动执行",
 	composerModeAskHint: "问答模式：只读排查，解答疑问，不修改代码",
 	composerModeTaskHint: "任务模式：确认方案后全自动实现并自检完成目标",
-	runningHint:
-		"执行中 Enter 加入待发送 · 点编辑拉回输入框 · 引导提交不中断当前",
+	runningHint: "执行中 Enter 加入待发送 · 点编辑拉回输入框 · 引导提交不中断当前",
 	queueTitle: "待发送",
 	queueEdit: "编辑（拉回输入框）",
 	queueEditPlaceholder: "编辑待发送内容…",
@@ -386,6 +385,14 @@ export const zh = {
 	gitErr_unknown: "Git 操作失败",
 	appearance: "外观",
 	notifyTitle: "通知",
+	proxyTitle: "网络代理",
+	proxyModeOff: "关闭",
+	proxyModeSystem: "自动",
+	proxyModeCustom: "手动",
+	proxyUrlLabel: "代理地址",
+	proxyUrlPlaceholder: "http://127.0.0.1:7890 或 socks5://127.0.0.1:1080",
+	proxyApplied: "代理设置已生效",
+	proxyInvalidUrl: "代理地址无效，请输入 http / https / socks5 地址",
 	notifySound: "完成提示音",
 	notifySoundHint: "回合完成时播放内置提示音（窗口在前台时也会播放）。",
 	notifySystem: "系统通知",
@@ -437,15 +444,15 @@ export const zh = {
 	ttsUnsupported: "当前系统暂不支持 Piper TTS（需 Windows x64 或 macOS）",
 	ttsRuntimeHint: (name: string) =>
 		`当前系统运行时：${name}（语音模型跨系统共用，不会重复下载）`,
-	asrHint: "本地 SenseVoiceSmall Q4_K GGUF（约 129 MB，多语言），默认不下载。关闭后不会加载模型。",
+	asrHint:
+		"本地 SenseVoiceSmall Q4_K GGUF（约 129 MB，多语言），默认不下载。关闭后不会加载模型。",
 	asrEnable: "启用语音输入",
 	asrWakeHotkey: "唤醒快捷键",
 	asrWakeHotkeyHint:
 		"点击下方按钮，再按下组合键即可改写。唤醒后按 Enter 确认识别，Esc 取消。",
 	asrWakeHotkeyListening: "按下组合键…（Esc 取消改键）",
 	asrWakeHotkeySaved: "快捷键已更新",
-	asrWakeHotkeyInvalid:
-		"无效组合键，请至少包含一个修饰键（Ctrl / Alt / Shift）",
+	asrWakeHotkeyInvalid: "无效组合键，请至少包含一个修饰键（Ctrl / Alt / Shift）",
 	asrWakeHotkeyInUse: "该快捷键已被占用，请换一组",
 	asrResidentModel: "常驻模型加载",
 	asrWakeEnabled: "语音唤醒",
@@ -601,10 +608,12 @@ export const zh = {
 	lanConsoleCredsRequired: "请填写用户名和密码",
 	lanConsoleCredsSaved: "凭据已保存",
 	lanConsoleTitle: "局域网网页控制台",
-	lanConsoleEnableHint: "默认关闭。开启后，局域网内设备可通过浏览器访问本机，浏览工作区/会话、聊天并语音识别（需 Token 鉴权）。",
+	lanConsoleEnableHint:
+		"默认关闭。开启后，局域网内设备可通过浏览器访问本机，浏览工作区/会话、聊天并语音识别（需 Token 鉴权）。",
 	lanConsoleUrl: "访问地址",
 	lanConsoleAddresses: "可选地址",
-	lanConsoleAddressesHint: "本机可能有多个网卡。若手机扫码连不上，请点选 Wi‑Fi / 以太网对应的 192.168.x.x 地址。",
+	lanConsoleAddressesHint:
+		"本机可能有多个网卡。若手机扫码连不上，请点选 Wi‑Fi / 以太网对应的 192.168.x.x 地址。",
 	lanConsoleRecommended: "推荐",
 	lanConsoleToken: "访问 Token",
 	lanConsoleCopy: "复制",
@@ -613,7 +622,8 @@ export const zh = {
 	lanConsolePort: "端口",
 	lanConsoleSavePort: "保存端口",
 	lanConsoleScan: "手机扫码访问",
-	lanConsoleCertHint: "首次打开会提示证书不受信任，选择「继续访问」即可（麦克风需要 HTTPS）。",
+	lanConsoleCertHint:
+		"首次打开会提示证书不受信任，选择「继续访问」即可（麦克风需要 HTTPS）。",
 	lanConsoleDisabledNote: "未开启。保持默认关闭，不暴露任何端口。",
 	lanConsoleStarted: "已开启局域网网页",
 	lanConsolePortInvalid: "无效的端口",
@@ -763,7 +773,8 @@ export const zh = {
 	modelsCustomApply: "应用到配置",
 	modelsCustomApplied: "已写入编辑中的 models.json，请点保存生效",
 	modelsCustomDelete: "删除自定义 Provider",
-	modelsCustomDeleteConfirm: (id: string) => `立即从 models.json 删除「${id}」？此操作会马上生效。`,
+	modelsCustomDeleteConfirm: (id: string) =>
+		`立即从 models.json 删除「${id}」？此操作会马上生效。`,
 	modelsCustomDeleted: "已删除",
 	modelsNeedsKey: "需配置 API Key",
 	modelsNothingToAdd: "没有可添加的 Provider（可能均已配置）",
@@ -851,8 +862,7 @@ export const zh = {
 	fileDeletedSavePrompt: "你需要保存吗？保存将重新创建该文件。",
 	dontSave: "不保存",
 	unsavedChangesTitle: "未保存的更改",
-	unsavedChangesClose: (label: string) =>
-		`「${label}」已修改，关闭前是否保存？`,
+	unsavedChangesClose: (label: string) => `「${label}」已修改，关闭前是否保存？`,
 
 	// Browser
 	cannotBookmark: "当前页面无法收藏",

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -282,6 +282,11 @@ export const IpcChannels = {
 		get: "security:get",
 		set: "security:set",
 	},
+	proxy: {
+		get: "proxy:get",
+		set: "proxy:set",
+		changed: "proxy:changed",
+	},
 } as const;
 
 export type TrustPromptKind = "none" | "ask";
@@ -295,25 +300,25 @@ export type TrustState = {
 
 export type SessionStatus = "idle" | "running" | "error" | "stuck";
 
-	/** LAN web console status exposed to the settings UI. */
-	export type LanConsoleStatus = {
-	  enabled: boolean;
-	  port: number;
-	  /** Configured login username (empty until set). */
-	  username: string;
-	  /** True once both username and password are configured. */
-	  hasCredentials: boolean;
-	  /** Selected LAN IPv4 used for QR / copy (best-effort ranked when unset). */
-	  preferredIp: string;
-	  /** All candidate LAN IPv4s, preferred/best-ranked first. */
-	  addresses: string[];
-	  /** HTTPS URLs for each address (same order as `addresses`). */
-	  urls: string[];
-	  /** Preferred access URL, e.g. https://192.168.1.5:18700. */
-	  baseUrl: string;
-	  /** Full URL for opening the console (login is username/password based). */
-	  url: string;
-	};
+/** LAN web console status exposed to the settings UI. */
+export type LanConsoleStatus = {
+	enabled: boolean;
+	port: number;
+	/** Configured login username (empty until set). */
+	username: string;
+	/** True once both username and password are configured. */
+	hasCredentials: boolean;
+	/** Selected LAN IPv4 used for QR / copy (best-effort ranked when unset). */
+	preferredIp: string;
+	/** All candidate LAN IPv4s, preferred/best-ranked first. */
+	addresses: string[];
+	/** HTTPS URLs for each address (same order as `addresses`). */
+	urls: string[];
+	/** Preferred access URL, e.g. https://192.168.1.5:18700. */
+	baseUrl: string;
+	/** Full URL for opening the console (login is username/password based). */
+	url: string;
+};
 
 /** Tools / extensions / skills loaded into a session worker (null while booting). */
 export type SessionExtensionInfo = {
@@ -441,7 +446,13 @@ export function isRegionCitation(
 
 /** Deep plain clone for Electron IPC (Vue proxies cannot be structured-cloned). */
 export function toIpcPlain<T>(value: T): T {
-	return JSON.parse(JSON.stringify(value)) as T;
+	const json = JSON.stringify(value);
+	try {
+		return JSON.parse(json) as T;
+	} catch {
+		// stringify succeeded, so parse cannot realistically fail.
+		return value;
+	}
 }
 
 /** Build Pi ImageContent list from composer/chat image payloads. */

--- a/src/shared/proxy.ts
+++ b/src/shared/proxy.ts
@@ -1,0 +1,94 @@
+export type ProxyMode = "off" | "system" | "custom";
+
+export type ProxySettings = {
+	mode: ProxyMode;
+	url: string;
+};
+
+export const DEFAULT_PROXY_SETTINGS: ProxySettings = {
+	mode: "off",
+	url: "",
+};
+
+export const PROXY_MODES: readonly ProxyMode[] = ["off", "system", "custom"];
+
+const ALLOWED_PROTOCOLS = new Set([
+	"http:",
+	"https:",
+	"socks4:",
+	"socks5:",
+	"socks:",
+]);
+
+export const PROXY_ENV_KEYS: readonly string[] = [
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"ALL_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"all_proxy",
+	"no_proxy",
+];
+
+export function normalizeProxyUrl(raw: string): string | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
+		? trimmed
+		: `http://${trimmed}`;
+	let parsed: URL;
+	try {
+		parsed = new URL(withScheme);
+	} catch {
+		return null;
+	}
+	if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) return null;
+	if (!parsed.hostname) return null;
+	parsed.username = "";
+	parsed.password = "";
+	parsed.pathname = "";
+	parsed.search = "";
+	parsed.hash = "";
+	const out = parsed.toString();
+	return out.endsWith("/") ? out.slice(0, -1) : out;
+}
+
+export function proxyEnvFromUrl(url: string): Record<string, string> {
+	const normalized = normalizeProxyUrl(url);
+	if (!normalized) return {};
+	return {
+		HTTP_PROXY: normalized,
+		HTTPS_PROXY: normalized,
+		ALL_PROXY: normalized,
+		http_proxy: normalized,
+		https_proxy: normalized,
+		all_proxy: normalized,
+	};
+}
+
+/** Parse a `session.resolveProxy` result like "PROXY host:port; DIRECT". */
+export function proxyEnvFromPacResult(
+	pacResult: string,
+): Record<string, string> {
+	const first = pacResult.split(";")[0]?.trim() ?? "";
+	const match = /^(PROXY|HTTPS|SOCKS|SOCKS4|SOCKS5)\s+(\S+)$/i.exec(first);
+	if (!match) return {};
+	const schemeByToken: Record<string, string> = {
+		proxy: "http",
+		https: "https",
+		socks: "socks5",
+		socks4: "socks4",
+		socks5: "socks5",
+	};
+	const scheme = schemeByToken[match[1].toLowerCase()];
+	if (!scheme) return {};
+	return proxyEnvFromUrl(`${scheme}://${match[2]}`);
+}
+
+export function isProxyActive(settings: ProxySettings): boolean {
+	if (settings.mode === "system") return true;
+	if (settings.mode === "custom")
+		return normalizeProxyUrl(settings.url) !== null;
+	return false;
+}

--- a/src/shared/session-timing.ts
+++ b/src/shared/session-timing.ts
@@ -1,0 +1,38 @@
+export type SessionTiming = {
+	llmMs: number;
+	ttftMs: number;
+	ttftSteps: number;
+	decodeMs: number;
+	outputTokens: number;
+};
+
+export const SESSION_TIMING_SUFFIX = ".timing.json";
+
+export function sessionTimingPath(filePath: string): string {
+	return `${filePath}${SESSION_TIMING_SUFFIX}`;
+}
+
+function finiteNonNegative(v: unknown): v is number {
+	return typeof v === "number" && Number.isFinite(v) && v >= 0;
+}
+
+export function parseSessionTiming(raw: unknown): SessionTiming | null {
+	if (!raw || typeof raw !== "object") return null;
+	const t = raw as Record<string, unknown>;
+	if (
+		!finiteNonNegative(t.llmMs) ||
+		!finiteNonNegative(t.ttftMs) ||
+		!finiteNonNegative(t.ttftSteps) ||
+		!finiteNonNegative(t.decodeMs) ||
+		!finiteNonNegative(t.outputTokens)
+	) {
+		return null;
+	}
+	return {
+		llmMs: t.llmMs,
+		ttftMs: t.ttftMs,
+		ttftSteps: t.ttftSteps,
+		decodeMs: t.decodeMs,
+		outputTokens: t.outputTokens,
+	};
+}

--- a/tests/agent-worker/session-timing.test.ts
+++ b/tests/agent-worker/session-timing.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { SessionTimingTracker } from "../../src/agent-worker/context-usage";
+import {
+  parseSessionTiming,
+  sessionTimingPath,
+} from "../../src/shared/session-timing";
+
+describe("session-timing sidecar", () => {
+  it("derives the sidecar path from the session file", () => {
+    expect(sessionTimingPath("/tmp/sessions/abc.jsonl")).toBe(
+      "/tmp/sessions/abc.jsonl.timing.json",
+    );
+  });
+
+  it("parses a valid persisted payload", () => {
+    const timing = parseSessionTiming({
+      llmMs: 1200,
+      ttftMs: 600,
+      ttftSteps: 2,
+      decodeMs: 800,
+      outputTokens: 100,
+    });
+    expect(timing).toEqual({
+      llmMs: 1200,
+      ttftMs: 600,
+      ttftSteps: 2,
+      decodeMs: 800,
+      outputTokens: 100,
+    });
+  });
+
+  it("rejects corrupt payloads", () => {
+    expect(parseSessionTiming(null)).toBeNull();
+    expect(parseSessionTiming({})).toBeNull();
+    expect(
+      parseSessionTiming({
+        llmMs: -1,
+        ttftMs: 0,
+        ttftSteps: 0,
+        decodeMs: 0,
+        outputTokens: 0,
+      }),
+    ).toBeNull();
+    expect(
+      parseSessionTiming({
+        llmMs: "x",
+        ttftMs: 0,
+        ttftSteps: 0,
+        decodeMs: 0,
+        outputTokens: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("restore() seeds totals so reopened sessions keep their stats", () => {
+    const tracker = new SessionTimingTracker();
+    tracker.restore({
+      llmMs: 10_000,
+      ttftMs: 900,
+      ttftSteps: 3,
+      decodeMs: 5_000,
+      outputTokens: 250,
+    });
+    const snap = tracker.snapshot();
+    expect(snap.llmMs).toBe(10_000);
+    expect(snap.ttftMs).toBe(900);
+    expect(snap.ttftSteps).toBe(3);
+    expect(snap.decodeMs).toBe(5_000);
+    expect(snap.outputTokens).toBe(250);
+    tracker.observe({ type: "turn_start" });
+    tracker.observe({
+      type: "message_end",
+      message: { role: "assistant", usage: { output: 10 } },
+    });
+    expect(tracker.snapshot().ttftSteps).toBe(3);
+    expect(tracker.snapshot().outputTokens).toBe(250);
+    expect(tracker.snapshot().llmMs).toBeGreaterThanOrEqual(10_000);
+  });
+});

--- a/tests/shared/proxy.test.ts
+++ b/tests/shared/proxy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PROXY_SETTINGS,
+  isProxyActive,
+  normalizeProxyUrl,
+  PROXY_ENV_KEYS,
+  proxyEnvFromPacResult,
+  proxyEnvFromUrl,
+} from "../../src/shared/proxy";
+
+describe("normalizeProxyUrl", () => {
+  it("accepts full http/https/socks5 URLs", () => {
+    expect(normalizeProxyUrl("http://127.0.0.1:7890")).toBe(
+      "http://127.0.0.1:7890",
+    );
+    expect(normalizeProxyUrl("https://proxy.example.com:8443")).toBe(
+      "https://proxy.example.com:8443",
+    );
+    expect(normalizeProxyUrl("socks5://127.0.0.1:1080")).toBe(
+      "socks5://127.0.0.1:1080",
+    );
+  });
+
+  it("adds http:// when the scheme is missing", () => {
+    expect(normalizeProxyUrl("127.0.0.1:7890")).toBe("http://127.0.0.1:7890");
+    expect(normalizeProxyUrl("proxy.local:3128")).toBe(
+      "http://proxy.local:3128",
+    );
+  });
+
+  it("strips credentials, path and trailing slash", () => {
+    expect(normalizeProxyUrl("http://user:pass@127.0.0.1:7890/")).toBe(
+      "http://127.0.0.1:7890",
+    );
+    expect(normalizeProxyUrl("http://127.0.0.1:7890/some/path?q=1#f")).toBe(
+      "http://127.0.0.1:7890",
+    );
+  });
+
+  it("rejects empty input and unsupported protocols", () => {
+    expect(normalizeProxyUrl("")).toBeNull();
+    expect(normalizeProxyUrl("   ")).toBeNull();
+    expect(normalizeProxyUrl("ftp://127.0.0.1:21")).toBeNull();
+    expect(normalizeProxyUrl("not a url ::")).toBeNull();
+    expect(normalizeProxyUrl("http://")).toBeNull();
+  });
+});
+
+describe("proxyEnvFromUrl", () => {
+  it("produces upper- and lowercase env vars", () => {
+    const env = proxyEnvFromUrl("http://127.0.0.1:7890");
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.ALL_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.http_proxy).toBe("http://127.0.0.1:7890");
+    expect(env.https_proxy).toBe("http://127.0.0.1:7890");
+    expect(env.all_proxy).toBe("http://127.0.0.1:7890");
+  });
+
+  it("returns an empty object for invalid URLs", () => {
+    expect(proxyEnvFromUrl("not a url")).toEqual({});
+  });
+
+  it("PROXY_ENV_KEYS covers every key proxyEnvFromUrl sets (plus NO_PROXY)", () => {
+    for (const key of Object.keys(proxyEnvFromUrl("http://127.0.0.1:7890"))) {
+      expect(PROXY_ENV_KEYS).toContain(key);
+    }
+    expect(PROXY_ENV_KEYS).toContain("NO_PROXY");
+    expect(PROXY_ENV_KEYS).toContain("no_proxy");
+  });
+});
+
+describe("proxyEnvFromPacResult", () => {
+  it("maps PROXY entries to http:// env vars", () => {
+    const env = proxyEnvFromPacResult("PROXY 192.168.1.10:8080; DIRECT");
+    expect(env.HTTP_PROXY).toBe("http://192.168.1.10:8080");
+  });
+
+  it("maps SOCKS5 entries to socks5:// env vars", () => {
+    const env = proxyEnvFromPacResult("SOCKS5 127.0.0.1:1080");
+    expect(env.ALL_PROXY).toBe("socks5://127.0.0.1:1080");
+  });
+
+  it("returns {} for DIRECT and garbage", () => {
+    expect(proxyEnvFromPacResult("DIRECT")).toEqual({});
+    expect(proxyEnvFromPacResult("")).toEqual({});
+    expect(proxyEnvFromPacResult("???")).toEqual({});
+  });
+});
+
+describe("isProxyActive", () => {
+  it("reflects mode and URL validity", () => {
+    expect(isProxyActive(DEFAULT_PROXY_SETTINGS)).toBe(false);
+    expect(isProxyActive({ mode: "system", url: "" })).toBe(true);
+    expect(
+      isProxyActive({ mode: "custom", url: "http://127.0.0.1:7890" }),
+    ).toBe(true);
+    expect(isProxyActive({ mode: "custom", url: "garbage :: :" })).toBe(false);
+  });
+});


### PR DESCRIPTION
新增支持网络代理配置，解决 #8。

Closes #8

---

## 追加：修复 0.3.0 开旧会话加载首 token 平均耗时失败

- 重构会话计时逻辑，新增 `src/shared/session-timing.ts`
- 修复 `context-usage` / `runtime` 中旧会话首个 token 平均耗时计算失败的问题
- 更新 `session-broker` / `session-history`
- 新增对应单元测试（`tests/agent-worker/session-timing.test.ts`）